### PR TITLE
Define StreamProvider Interface and related factory

### DIFF
--- a/src/main/java/com/alvarium/PublishWrapper.java
+++ b/src/main/java/com/alvarium/PublishWrapper.java
@@ -1,0 +1,43 @@
+package com.alvarium;
+
+import java.io.Serializable;
+
+import com.google.gson.Gson;
+
+/**
+ * A java bean that encapsulates the content sent through the stream providers
+ * and appends the required metadata
+ */
+public class PublishWrapper implements Serializable {
+  private final SdkAction action;
+  private final String messageType;
+  private final Object content;
+
+  public PublishWrapper(SdkAction action, String messageType, Object content) {
+    this.action = action;
+    this.messageType = messageType;
+    this.content = content;
+  }
+
+  public SdkAction getAction() {
+    return action;
+  }
+
+  public String getMessageType() {
+    return messageType;
+  }
+
+  public Object getContent() {
+    return content;
+  }
+
+  public static PublishWrapper fromJson(String json) {
+    Gson gson = new Gson();
+    return gson.fromJson(json, PublishWrapper.class);
+  }
+
+  public String toJson() {
+    Gson gson = new Gson();
+    return gson.toJson(this);
+  }
+}

--- a/src/main/java/com/alvarium/SdkAction.java
+++ b/src/main/java/com/alvarium/SdkAction.java
@@ -1,0 +1,8 @@
+package com.alvarium;
+
+/**
+ * An identifier for the operations performed by the sdk
+ */
+public enum SdkAction {
+  CREATE, MUTATE, TRANSIT  
+}

--- a/src/main/java/com/alvarium/streams/MockStreamProvider.java
+++ b/src/main/java/com/alvarium/streams/MockStreamProvider.java
@@ -1,0 +1,21 @@
+package com.alvarium.streams;
+
+import com.alvarium.PublishWrapper;
+
+/**
+ * A dummy stream provider that does not throw any errors
+ * Mainly used for unit tests
+ */
+class MockStreamProvider implements StreamProvider {
+  public void connect() {
+    System.out.println("stream connected");
+  }
+  
+  public void close() {
+    System.out.println("stream closed");
+  }
+  
+  public void publish(PublishWrapper wrapper) {
+    System.out.println(String.format("%s publish", wrapper.toJson()));
+  }
+}

--- a/src/main/java/com/alvarium/streams/StreamException.java
+++ b/src/main/java/com/alvarium/streams/StreamException.java
@@ -1,0 +1,15 @@
+package com.alvarium.streams;
+
+/**
+ * A general type exception that encapsulates all exceptions related to stream providers
+ */
+public class StreamException extends Exception {
+
+  public StreamException(String msg) {
+    super(msg);
+  }
+
+  public StreamException(String msg, Exception e) {
+    super(msg, e);
+  }
+}

--- a/src/main/java/com/alvarium/streams/StreamProvider.java
+++ b/src/main/java/com/alvarium/streams/StreamProvider.java
@@ -1,0 +1,27 @@
+package com.alvarium.streams;
+
+import com.alvarium.PublishWrapper;
+
+/**
+ * A unit that provides a way for the sdk to connect and publish data to an external pub/sub model
+ */
+public interface StreamProvider {
+  /**
+   * connects to an external unit to be able to publish ongoing data
+   * @throws StreamException: thrown when it fails to connect to the external unit
+   */
+  public void connect() throws StreamException;
+
+  /**
+   * closes the previously opened connection
+   * @throws StreamException: thrown when the connection is already closed
+   */
+  public void close() throws StreamException;
+
+  /**
+   * publishes the passed data to the external unit through the established connection
+   * @param wrapper : data being published
+   * @throws StreamException: thrown if the connection is closed or if the unit did not respond
+   */
+  public void publish(PublishWrapper wrapper) throws StreamException; 
+}

--- a/src/main/java/com/alvarium/streams/StreamProviderFactory.java
+++ b/src/main/java/com/alvarium/streams/StreamProviderFactory.java
@@ -1,0 +1,16 @@
+package com.alvarium.streams;
+
+/**
+ * A factory that provides different implementations of the StreamProvider interface
+ */
+public class StreamProviderFactory {
+  public StreamProvider getProvider(StreamType type) throws StreamException {
+    switch (type) {
+      case MOCK:
+        return new MockStreamProvider();
+    
+      default:
+        throw new StreamException(String.format("%s is not supported", type));
+    }  
+  }
+}

--- a/src/main/java/com/alvarium/streams/StreamType.java
+++ b/src/main/java/com/alvarium/streams/StreamType.java
@@ -1,0 +1,8 @@
+package com.alvarium.streams;
+
+/**
+ * An identifier for the stream used by the sdk
+ */
+public enum StreamType {
+  MOCK  
+}

--- a/src/test/java/com/alvarium/PublishWrapperTest.java
+++ b/src/test/java/com/alvarium/PublishWrapperTest.java
@@ -1,0 +1,36 @@
+package com.alvarium;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class PublishWrapperTest {
+
+  @Test
+  public void toJsonShouldReturnAppropriateRepresentation() {
+    final SdkAction action = SdkAction.CREATE;
+    final String messageType = "test type";
+    final ArrayList<Integer> content = new ArrayList<Integer>(Arrays.asList(1,2,3,4));     
+
+    final PublishWrapper wrapper = new PublishWrapper(action,messageType, content);
+    System.out.println(wrapper.toJson());
+  }  
+
+  @Test
+  public void fromJsonShouldReturnAppropriateObject() throws IOException {
+    String path = "./src/test/java/com/alvarium/publishWrapperData.json";
+    final String testJson = Files.readString(Paths.get(path), StandardCharsets.US_ASCII);
+
+    final PublishWrapper wrapper = PublishWrapper.fromJson(testJson);
+    assertEquals(SdkAction.CREATE, wrapper.getAction());
+    assertEquals("test type", wrapper.getMessageType()); 
+    assertEquals("test content", wrapper.getContent());
+   }
+}

--- a/src/test/java/com/alvarium/publishWrapperData.json
+++ b/src/test/java/com/alvarium/publishWrapperData.json
@@ -1,0 +1,5 @@
+{
+  "action": "CREATE",
+  "messageType": "test type",
+  "content": "test content" 
+}

--- a/src/test/java/com/alvarium/streams/StreamProviderTest.java
+++ b/src/test/java/com/alvarium/streams/StreamProviderTest.java
@@ -1,0 +1,21 @@
+package com.alvarium.streams;
+
+import com.alvarium.PublishWrapper;
+import com.alvarium.SdkAction;
+
+import org.junit.Test;
+
+public class StreamProviderTest {
+  @Test
+  public void mockStreamProviderShouldNotThrow() throws StreamException {
+    final StreamProviderFactory factory = new StreamProviderFactory();
+    final StreamProvider provider = factory.getProvider(StreamType.MOCK);
+    final PublishWrapper wrapper = new PublishWrapper(SdkAction.CREATE, "test type",
+        "test content");
+
+
+    provider.connect();
+    provider.publish(wrapper);
+    provider.close();
+  }  
+}


### PR DESCRIPTION
* add gson dependency to pom.xml
* create SdkAction enum
* create PublishWrapper class with the toJson and
  fromJson methods
* create StreamProvider interface
* create general StreamException
* implement MockStreamProvider to conform to the
  StreamProvider interface
* implement the StreamProviderFactory
* implement related unit tests

Fix #29

Signed-off-by: Karim Elghamry <karimelghamry@gmail.com>