### PR TITLE
Define Annotator interface and related factory

### DIFF
--- a/src/main/java/com/alvarium/annotators/Annotator.java
+++ b/src/main/java/com/alvarium/annotators/Annotator.java
@@ -1,0 +1,18 @@
+package com.alvarium.annotators;
+
+import com.alvarium.contracts.Annotation;
+import com.alvarium.utils.PropertyBag;
+
+/**
+ * A unit responsible for annotating raw data and producing an Annotation object
+ */
+public interface Annotator {
+  /**
+   * creates an Annotation from the given raw data
+   * @param ctx
+   * @param data
+   * @return Annotation object
+   * @throws AnnotatorException
+   */
+  public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException;  
+}

--- a/src/main/java/com/alvarium/annotators/AnnotatorException.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorException.java
@@ -1,0 +1,14 @@
+package com.alvarium.annotators;
+
+/**
+ * a general exception type to be used by the annotators
+ */
+public class AnnotatorException extends Exception {
+  public AnnotatorException(String msg) {
+    super(msg);
+  }
+
+  public AnnotatorException(String msg, Exception e) {
+    super(msg, e);
+  }
+}

--- a/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
@@ -1,0 +1,18 @@
+package com.alvarium.annotators;
+
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashType;
+import com.alvarium.sign.SignatureInfo;
+
+public class AnnotatorFactory {
+
+  public Annotator getAnnotator(AnnotationType kind, HashType hash, SignatureInfo signature) 
+      throws AnnotatorException {
+    switch (kind) {
+      case MOCK:
+        return new MockAnnotator(hash, kind, signature);
+      default:
+        throw new AnnotatorException("Annotator type is not supported"); 
+    }
+  }  
+}

--- a/src/main/java/com/alvarium/annotators/MockAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/MockAnnotator.java
@@ -1,0 +1,44 @@
+package com.alvarium.annotators;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Instant;
+
+import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashProviderFactory;
+import com.alvarium.hash.HashType;
+import com.alvarium.hash.HashTypeException;
+import com.alvarium.sign.SignatureInfo;
+import com.alvarium.utils.PropertyBag;
+
+/**
+ * a dummy annotator to be used in unit tests
+ */
+class MockAnnotator implements Annotator {
+  private final HashType hash;
+  private final AnnotationType kind;
+  private final SignatureInfo signature;
+
+  protected MockAnnotator(HashType hash, AnnotationType kind, SignatureInfo signature) {
+    this.hash = hash;
+    this.kind = kind;
+    this.signature = signature;
+  }
+
+  public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
+    final HashProviderFactory hashFactory = new HashProviderFactory();
+    try {
+      final String key = hashFactory.getProvider(hash).derive(data);
+      final String host = InetAddress.getLocalHost().getHostName();
+      final String sig = signature.getPublicKey().getType().toString();
+
+      final Annotation annotation = new Annotation(key, hash, host, kind, sig, true, Instant.now());
+      return annotation;
+    } catch (HashTypeException e) {
+      throw new AnnotatorException("failed to hash data", e);
+    } catch (UnknownHostException e) {
+      throw new AnnotatorException("Could not get hostname", e);
+    }
+  } 
+}

--- a/src/main/java/com/alvarium/contracts/AnnotationType.java
+++ b/src/main/java/com/alvarium/contracts/AnnotationType.java
@@ -1,5 +1,5 @@
 package com.alvarium.contracts;
 
 public enum AnnotationType {
-  TPM 
+  TPM, MOCK 
 }

--- a/src/main/java/com/alvarium/sign/KeyInfo.java
+++ b/src/main/java/com/alvarium/sign/KeyInfo.java
@@ -1,0 +1,36 @@
+package com.alvarium.sign;
+
+import java.io.Serializable;
+
+import com.google.gson.Gson;
+
+/**
+ * a java bean that encapsulates the metadata related to a specific crypto key
+ */
+public class KeyInfo implements Serializable {
+  private final String path;
+  private final SignType type; 
+
+  public KeyInfo(String path, SignType type) {
+    this.path = path;
+    this.type = type;
+  }
+
+  public String getPath() {
+    return this.path;
+  }
+
+  public SignType getType() {
+    return this.type;
+  }
+
+  public String toJson() {
+    Gson gson = new Gson();
+    return gson.toJson(this);
+  }
+
+  public static KeyInfo fromJson(String json) {
+    Gson gson = new Gson();
+    return gson.fromJson(json, KeyInfo.class);
+  }
+}

--- a/src/main/java/com/alvarium/sign/SignatureInfo.java
+++ b/src/main/java/com/alvarium/sign/SignatureInfo.java
@@ -1,0 +1,39 @@
+package com.alvarium.sign;
+
+import java.io.Serializable;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * a java bean that encapsulates the private and public keys used in signature operations
+ */
+public class SignatureInfo implements Serializable {
+  @SerializedName(value = "public", alternate = "publicKey")
+  private final KeyInfo publicKey;  
+  @SerializedName(value = "private", alternate = "privateKey")
+  private final KeyInfo privateKey;
+
+  public SignatureInfo(KeyInfo publicKey, KeyInfo privateKey) {
+    this.publicKey = publicKey;
+    this.privateKey = privateKey;
+  }
+
+  public KeyInfo getPublicKey() {
+    return this.publicKey;
+  }
+
+  public KeyInfo getPrivateKey() {
+    return this.privateKey;
+  }
+
+  public String toJson() {
+    Gson gson = new Gson();
+    return gson.toJson(this);
+  }
+
+  public static SignatureInfo fromJson(String json) {
+    Gson gson = new Gson();
+    return gson.fromJson(json, SignatureInfo.class);
+  }
+}

--- a/src/main/java/com/alvarium/utils/PropertyBag.java
+++ b/src/main/java/com/alvarium/utils/PropertyBag.java
@@ -4,5 +4,6 @@ import java.util.Map;
 
 public interface PropertyBag {
   public <T> T getProperty(String key, Class<T> c);
-  public Map<String,Object> toMap();
+
+  public Map<String, Object> toMap();
 }

--- a/src/test/java/com/alvarium/annotators/AnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/AnnotatorTest.java
@@ -1,0 +1,30 @@
+package com.alvarium.annotators;
+
+import java.util.HashMap;
+
+import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashType;
+import com.alvarium.sign.KeyInfo;
+import com.alvarium.sign.SignType;
+import com.alvarium.sign.SignatureInfo;
+import com.alvarium.utils.ImmutablePropertyBag;
+import com.alvarium.utils.PropertyBag;
+
+import org.junit.Test;
+
+public class AnnotatorTest {
+  @Test
+  public void mockAnnotatorShouldReturnAnnotation() throws AnnotatorException {
+    final KeyInfo keyInfo = new KeyInfo("path", SignType.none);
+    final SignatureInfo signature = new SignatureInfo(keyInfo, keyInfo);
+    final AnnotatorFactory factory = new AnnotatorFactory();
+    final Annotator annotator = factory.getAnnotator(AnnotationType.MOCK, HashType.MD5Hash,
+        signature);
+    final byte[] data = "test data".getBytes();
+    final PropertyBag ctx = new ImmutablePropertyBag(new HashMap<>());
+    final Annotation annotation = annotator.execute(ctx, data);
+
+    System.out.println(annotation.toJson());
+  }  
+}

--- a/src/test/java/com/alvarium/sign/KeyInfoTest.java
+++ b/src/test/java/com/alvarium/sign/KeyInfoTest.java
@@ -1,0 +1,28 @@
+package com.alvarium.sign;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+public class KeyInfoTest {
+  @Test
+  public void toJsonShouldReturnAppropriateRepresentation() {
+    final KeyInfo keyInfo = new KeyInfo("./key.json", SignType.Ed25519);
+    System.out.println(keyInfo.toJson());
+  }  
+
+  @Test
+  public void fromJsonShouldReturnAnObjectWithTheRightProps() throws IOException {
+    String path = "./src/test/java/com/alvarium/sign/keyInfoData.json";
+    final String testJson = Files.readString(Paths.get(path), StandardCharsets.US_ASCII);
+
+    final KeyInfo keyInfo = KeyInfo.fromJson(testJson);
+    assertEquals("./key.json", keyInfo.getPath());
+    assertEquals(SignType.Ed25519, keyInfo.getType());
+  }
+}

--- a/src/test/java/com/alvarium/sign/SignatureInfoTest.java
+++ b/src/test/java/com/alvarium/sign/SignatureInfoTest.java
@@ -1,0 +1,30 @@
+package com.alvarium.sign;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+public class SignatureInfoTest {
+  @Test
+  public void toJsonShouldReturnAppropriateRepresentation() {
+    final KeyInfo keyInfo = new KeyInfo("./key.json", SignType.Ed25519);
+    final SignatureInfo sig = new SignatureInfo(keyInfo, keyInfo);
+    
+    System.out.println(sig.toJson());
+  }
+
+  @Test
+  public void fromJsonShouldReturnAnObjectWithTheRightProps() throws IOException{
+    String path = "./src/test/java/com/alvarium/sign/signatureInfoData.json";
+    final String testJson = Files.readString(Paths.get(path), StandardCharsets.US_ASCII);
+
+    final SignatureInfo sig = SignatureInfo.fromJson(testJson);
+    assertEquals(KeyInfo.class, sig.getPublicKey().getClass());
+    assertEquals(KeyInfo.class, sig.getPrivateKey().getClass());
+  }
+}

--- a/src/test/java/com/alvarium/sign/keyInfoData.json
+++ b/src/test/java/com/alvarium/sign/keyInfoData.json
@@ -1,0 +1,4 @@
+{
+  "path": "./key.json",
+  "type": "Ed25519"  
+}

--- a/src/test/java/com/alvarium/sign/signatureInfoData.json
+++ b/src/test/java/com/alvarium/sign/signatureInfoData.json
@@ -1,0 +1,4 @@
+{
+  "public": { "path": "./key.json", "type": "Ed25519" },
+  "private": { "path": "./key.json", "type": "Ed25519" }
+}


### PR DESCRIPTION
* Add annotator interface
* Add general AnnotatorException type
* Add KeyInfo class as a java bean
* Add SignatureInfo class as a java bean
* Implement MockAnnotator which is used in unit tests
* Implement and expose AnnotatorFactory class
* Implement all related unit tests

Fix #33

Signed-off-by: Karim Elghamry <karimelghamry@gmail.com>