### PR TITLE
Add an Annotation serializer to be used in PublishWapper

### DIFF
--- a/src/main/java/com/alvarium/PublishWrapper.java
+++ b/src/main/java/com/alvarium/PublishWrapper.java
@@ -2,7 +2,10 @@ package com.alvarium;
 
 import java.io.Serializable;
 
+import com.alvarium.contracts.Annotation;
+import com.alvarium.serializers.AnnotationConverter;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 /**
  * A java bean that encapsulates the content sent through the stream providers
@@ -32,12 +35,14 @@ public class PublishWrapper implements Serializable {
   }
 
   public static PublishWrapper fromJson(String json) {
-    Gson gson = new Gson();
+    Gson gson = new GsonBuilder().registerTypeAdapter(Annotation.class, new AnnotationConverter())
+        .create();
     return gson.fromJson(json, PublishWrapper.class);
   }
 
   public String toJson() {
-    Gson gson = new Gson();
+    Gson gson = new GsonBuilder().registerTypeAdapter(Annotation.class, new AnnotationConverter())
+        .create();
     return gson.toJson(this);
   }
 }

--- a/src/main/java/com/alvarium/serializers/AnnotationConverter.java
+++ b/src/main/java/com/alvarium/serializers/AnnotationConverter.java
@@ -1,0 +1,23 @@
+package com.alvarium.serializers;
+
+import java.lang.reflect.Type;
+
+import com.alvarium.contracts.Annotation;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+
+public class AnnotationConverter implements JsonSerializer<Annotation>, JsonDeserializer<Annotation> {
+
+  public JsonElement serialize(Annotation src, Type typeOfSrc, JsonSerializationContext context) {
+    return JsonParser.parseString(src.toJson()); 
+  }
+
+  public Annotation deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+    return Annotation.fromJson(json.getAsString());
+  }
+}

--- a/src/test/java/com/alvarium/PublishWrapperTest.java
+++ b/src/test/java/com/alvarium/PublishWrapperTest.java
@@ -6,8 +6,13 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+
+import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashType;
 
 import org.junit.Test;
 
@@ -22,6 +27,18 @@ public class PublishWrapperTest {
     final PublishWrapper wrapper = new PublishWrapper(action,messageType, content);
     System.out.println(wrapper.toJson());
   }  
+
+  @Test
+  public void toJsonShouldParseAnnotationCorrectly() {
+    final SdkAction action = SdkAction.CREATE;
+    final String messageType = "test type";
+    final Annotation annotation = new Annotation("key", HashType.MD5Hash, "host", AnnotationType.TPM
+        , "signature", true, Instant.now());
+
+    final Annotation[] annotationList = {annotation, annotation};    
+    final PublishWrapper wrapper = new PublishWrapper(action, messageType, annotationList);
+    System.out.println(wrapper.toJson());
+  }
 
   @Test
   public void fromJsonShouldReturnAppropriateObject() throws IOException {


### PR DESCRIPTION
* Add an AnnotationConverter class to override
  the serialization process
* Use the implemented serializer in the PublishWrapper
  class
* implement unit test

Fix #32

Signed-off-by: Karim Elghamry <karimelghamry@gmail.com>