### PR TITLE
Enable sdk configuration driven customization

### DIFF
--- a/src/main/java/com/alvarium/SdkAction.java
+++ b/src/main/java/com/alvarium/SdkAction.java
@@ -1,8 +1,15 @@
 package com.alvarium;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * An identifier for the operations performed by the sdk
  */
 public enum SdkAction {
-  CREATE, MUTATE, TRANSIT  
+  @SerializedName(value = "create")
+  CREATE,
+  @SerializedName(value = "mutate")
+  MUTATE,
+  @SerializedName(value = "transit")
+  TRANSIT;
 }

--- a/src/main/java/com/alvarium/SdkInfo.java
+++ b/src/main/java/com/alvarium/SdkInfo.java
@@ -1,0 +1,57 @@
+package com.alvarium;
+
+import java.io.Serializable;
+
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashInfo;
+import com.alvarium.serializers.StreamInfoConverter;
+import com.alvarium.sign.SignatureInfo;
+import com.alvarium.streams.StreamInfo;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * A java bean that encapsulates sdk related configuration
+ */
+public class SdkInfo implements Serializable {
+  private final AnnotationType[] annotators;
+  private final HashInfo hash;
+  private final SignatureInfo signature;
+  private final StreamInfo stream;
+
+  public SdkInfo(AnnotationType[] annotators, HashInfo hash, SignatureInfo signature,
+      StreamInfo stream) {
+    this.annotators = annotators;
+    this.hash = hash;
+    this.signature = signature;
+    this.stream = stream;
+  }
+
+  public AnnotationType[] getAnnotators() {
+    return this.annotators;
+  }
+
+  public HashInfo getHash() {
+    return this.hash;
+  }
+
+  public SignatureInfo getSignature() {
+    return this.signature;
+  }
+
+  public StreamInfo getStream() {
+    return this.stream;
+  }
+
+  public String toJson() {
+    Gson gson = new GsonBuilder().registerTypeAdapter(StreamInfo.class, new StreamInfoConverter())
+        .create();
+    return gson.toJson(this);
+  }
+
+  public static SdkInfo fromJson(String json) {
+    Gson gson = new GsonBuilder().registerTypeAdapter(StreamInfo.class, new StreamInfoConverter())
+        .create();
+    return gson.fromJson(json, SdkInfo.class);
+  }
+}

--- a/src/main/java/com/alvarium/contracts/AnnotationType.java
+++ b/src/main/java/com/alvarium/contracts/AnnotationType.java
@@ -1,5 +1,10 @@
 package com.alvarium.contracts;
 
+import com.google.gson.annotations.SerializedName;
+
 public enum AnnotationType {
-  TPM, MOCK 
+  @SerializedName(value = "tpm")
+  TPM, 
+  @SerializedName(value = "mock")
+  MOCK;
 }

--- a/src/main/java/com/alvarium/hash/HashInfo.java
+++ b/src/main/java/com/alvarium/hash/HashInfo.java
@@ -1,0 +1,30 @@
+package com.alvarium.hash;
+
+import java.io.Serializable;
+
+import com.google.gson.Gson;
+
+/**
+ * A java bean that encapsulates all data related to hash providers
+ */
+public class HashInfo implements Serializable {
+  private final HashType type;
+
+  public HashInfo(HashType type) {
+    this.type = type;
+  }
+
+  public HashType getType(){
+    return this.type;
+  }
+
+  public String toJson() {
+    Gson gson = new Gson();
+    return gson.toJson(this);
+  }
+
+  public static HashInfo fromJson(String json) {
+    Gson gson = new Gson();
+    return gson.fromJson(json, HashInfo.class);
+  }
+}

--- a/src/main/java/com/alvarium/hash/HashType.java
+++ b/src/main/java/com/alvarium/hash/HashType.java
@@ -1,5 +1,12 @@
 package com.alvarium.hash;
 
+import com.google.gson.annotations.SerializedName;
+
 public enum HashType {
-  NoHash, MD5Hash, SHA256Hash
+  @SerializedName(value = "none")
+  NoHash,
+  @SerializedName(value = "md5")
+  MD5Hash,
+  @SerializedName(value = "sha256")
+  SHA256Hash;
 }

--- a/src/main/java/com/alvarium/serializers/StreamInfoConverter.java
+++ b/src/main/java/com/alvarium/serializers/StreamInfoConverter.java
@@ -26,7 +26,7 @@ public class StreamInfoConverter implements JsonDeserializer<StreamInfo> {
         JsonDeserializationContext context
     ) {
     JsonObject obj = json.getAsJsonObject();
-    StreamType type = StreamType.valueOf(obj.get("type").getAsString());
+    StreamType type = StreamType.valueOf(obj.get("type").getAsString().toUpperCase());
     switch(type){
       case MQTT: 
         MqttConfig config = MqttConfig.fromJson(obj.get("config").toString());

--- a/src/main/java/com/alvarium/sign/SignType.java
+++ b/src/main/java/com/alvarium/sign/SignType.java
@@ -1,6 +1,10 @@
 package com.alvarium.sign;
 
+import com.google.gson.annotations.SerializedName;
+
 public enum SignType {
+  @SerializedName(value = "ed25519")
   Ed25519,
-  none
+  @SerializedName(value = "none")
+  none;
  }

--- a/src/main/java/com/alvarium/streams/StreamType.java
+++ b/src/main/java/com/alvarium/streams/StreamType.java
@@ -1,9 +1,13 @@
 package com.alvarium.streams;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * An identifier for the stream used by the sdk
  */
 public enum StreamType {
+  @SerializedName(value = "mqtt")
   MQTT,
-  MOCK  
+  @SerializedName(value = "mock")
+  MOCK;
 }

--- a/src/test/java/com/alvarium/SdkInfoTest.java
+++ b/src/test/java/com/alvarium/SdkInfoTest.java
@@ -1,0 +1,36 @@
+package com.alvarium;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashType;
+import com.alvarium.sign.SignType;
+import com.alvarium.streams.MqttConfig;
+
+import org.junit.Test;
+
+public class SdkInfoTest {
+  private final String testJson;
+  private final AnnotationType[] annotators = {AnnotationType.TPM,AnnotationType.MOCK};
+
+  public SdkInfoTest() throws IOException {
+    String path = "./src/test/java/com/alvarium/sdk-info.json";
+    this.testJson = Files.readString(Paths.get(path), StandardCharsets.US_ASCII);
+  }
+
+  @Test
+  public void fromJsonShouldReturnSdkInfo(){
+    SdkInfo sdkInfo = SdkInfo.fromJson(this.testJson);
+
+    assertEquals(true, Arrays.equals(this.annotators, sdkInfo.getAnnotators()));
+    assertEquals(HashType.SHA256Hash, sdkInfo.getHash().getType());
+    assertEquals(SignType.Ed25519, sdkInfo.getSignature().getPrivateKey().getType());
+    assertEquals(MqttConfig.class, sdkInfo.getStream().getConfig().getClass());
+  } 
+}

--- a/src/test/java/com/alvarium/contracts/data.json
+++ b/src/test/java/com/alvarium/contracts/data.json
@@ -1,9 +1,9 @@
 {
   "id": "01FE0RFFJY94R1ER2AM9BG63E2",
   "key": "320",
-  "hash": "MD5Hash",
+  "hash": "md5",
   "host": "host",
-  "kind": "TPM",
+  "kind": "tpm",
   "signature": "test sign",
   "isSatisfied": true,
   "timestamp": "2021-08-24T12:22:33.334070489-05:00"

--- a/src/test/java/com/alvarium/publishWrapperData.json
+++ b/src/test/java/com/alvarium/publishWrapperData.json
@@ -1,5 +1,5 @@
 {
-  "action": "CREATE",
+  "action": "create",
   "messageType": "test type",
   "content": "test content" 
 }

--- a/src/test/java/com/alvarium/sdk-info.json
+++ b/src/test/java/com/alvarium/sdk-info.json
@@ -1,0 +1,32 @@
+{
+  "annotators": ["tpm", "mock"],
+  "hash": {
+    "type": "sha256"
+  },
+  "signature": {
+    "public": {
+      "type": "ed25519",
+      "path": "./res/keys/ed25519/public.key"
+    },
+    "private": {
+      "type": "ed25519",
+      "path": "./res/keys/ed25519/private.key"
+    }
+  },
+  "stream": {
+    "type": "mqtt",
+    "config": {
+      "clientId": "alvarium-test",
+      "qos": 0,
+      "user": "mosquitto",
+      "password": "",
+      "provider": {
+        "host": "localhost",
+        "protocol": "tcp",
+        "port": 1883
+      },
+      "cleanness": false,
+      "topics": ["alvarium-test-topic"]
+    }
+  }
+}

--- a/src/test/java/com/alvarium/sign/keyInfoData.json
+++ b/src/test/java/com/alvarium/sign/keyInfoData.json
@@ -1,4 +1,4 @@
 {
   "path": "./key.json",
-  "type": "Ed25519"  
+  "type": "ed25519"  
 }

--- a/src/test/java/com/alvarium/sign/signatureInfoData.json
+++ b/src/test/java/com/alvarium/sign/signatureInfoData.json
@@ -1,4 +1,4 @@
 {
-  "public": { "path": "./key.json", "type": "Ed25519" },
-  "private": { "path": "./key.json", "type": "Ed25519" }
+  "public": { "path": "./key.json", "type": "ed25519" },
+  "private": { "path": "./key.json", "type": "ed25519" }
 }

--- a/src/test/java/com/alvarium/streams/mqtt-config.json
+++ b/src/test/java/com/alvarium/streams/mqtt-config.json
@@ -1,5 +1,5 @@
 {
-  "type": "MQTT",
+  "type": "mqtt",
   "config": {
     "clientId": "alvarium-test",
     "qos": 0,


### PR DESCRIPTION
* Override enum literals serialization to match lowercase
  implemention of the go sdk
* Add HashInfo as a Java bean
* Add SdkInfo as a Java bean
* Implement unit tests

Fix #38 & Fix #42

Signed-off-by: Karim Elghamry <karimelghamry@gmail.com>