### PR TITLE
Implement Sdk constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,5 +48,18 @@
           <version>1.2.5</version>
         </dependency>
 
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>2.14.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>2.14.1</version>
+        <scope>test</scope>
+      </dependency>
+
     </dependencies>
 </project>

--- a/src/main/java/com/alvarium/DefaultSdk.java
+++ b/src/main/java/com/alvarium/DefaultSdk.java
@@ -1,14 +1,27 @@
 package com.alvarium;
 
+import com.alvarium.annotators.Annotator;
+import com.alvarium.streams.StreamException;
+import com.alvarium.streams.StreamProvider;
+import com.alvarium.streams.StreamProviderFactory;
 import com.alvarium.utils.PropertyBag;
 
+import org.apache.logging.log4j.Logger;
+
 public class DefaultSdk implements Sdk {
+  private final Annotator[] annotators;
+  private final SdkInfo config;
+  private final StreamProvider stream;
 
-  DefaultSdk() {
-    this.init();
-  }
+  DefaultSdk(Annotator[] annotators, SdkInfo config, Logger logger) throws StreamException {
+    this.annotators = annotators;
+    this.config = config;
 
-  private void init() {
+    // init stream
+    final StreamProviderFactory streamFactory = new StreamProviderFactory();
+    this.stream = streamFactory.getProvider(this.config.getStream());
+    this.stream.connect();
+    logger.debug("stream provider connected successfully.");
   }
 
   public void create(PropertyBag properties, byte[] data) {
@@ -20,6 +33,7 @@ public class DefaultSdk implements Sdk {
   public void transit(PropertyBag properties, byte[] data) {
   }
 
-  public void close() {
+  public void close() throws StreamException {
+    this.stream.close();
   }
 }

--- a/src/main/java/com/alvarium/Sdk.java
+++ b/src/main/java/com/alvarium/Sdk.java
@@ -1,5 +1,6 @@
 package com.alvarium;
 
+import com.alvarium.streams.StreamException;
 import com.alvarium.utils.PropertyBag;
 
 public interface Sdk {
@@ -7,5 +8,5 @@ public interface Sdk {
   public void create(PropertyBag properties, byte[] data);
   public void mutate(PropertyBag properties, byte[] oldData, byte[] newData);
   public void transit(PropertyBag properties, byte[] data);
-  public void close();
+  public void close() throws StreamException;
 }

--- a/src/test/java/com/alvarium/SdkInfoTest.java
+++ b/src/test/java/com/alvarium/SdkInfoTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 
 public class SdkInfoTest {
   private final String testJson;
-  private final AnnotationType[] annotators = {AnnotationType.TPM,AnnotationType.MOCK};
+  private final AnnotationType[] annotators = {AnnotationType.TLS,AnnotationType.MOCK};
 
   public SdkInfoTest() throws IOException {
     String path = "./src/test/java/com/alvarium/sdk-info.json";

--- a/src/test/java/com/alvarium/mock-info.json
+++ b/src/test/java/com/alvarium/mock-info.json
@@ -1,3 +1,4 @@
+
 {
   "annotators": ["tls", "mock"],
   "hash": {
@@ -14,19 +15,8 @@
     }
   },
   "stream": {
-    "type": "mqtt",
+    "type": "mock",
     "config": {
-      "clientId": "alvarium-test",
-      "qos": 0,
-      "user": "",
-      "password": "",
-      "provider": {
-        "host": "test.mosquitto.org",
-        "protocol": "tcp",
-        "port": 1883
-      },
-      "cleanness": false,
-      "topics": ["alvarium-test-topic"]
     }
   }
 }


### PR DESCRIPTION
* Add the required params to the Sdk Constructor
* Implement a close() method to cleanup the sdk
* Fix previous unit tests depending on the SdkInfo
* Implement related unit tests

Fix #49

Signed-off-by: Karim Elghamry <karimelghamry@gmail.com>