### PR TITLE
Add PKI Annotator implementation

### DIFF
--- a/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
@@ -13,6 +13,8 @@ public class AnnotatorFactory {
         return new MockAnnotator(hash, kind, signature);
       case TLS:
         return new TlsAnnotator(hash, signature);
+      case PKI:
+        return new PkiAnnotator(hash, signature);
       default:
         throw new AnnotatorException("Annotator type is not supported"); 
     }

--- a/src/main/java/com/alvarium/annotators/PkiAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/PkiAnnotator.java
@@ -1,0 +1,102 @@
+package com.alvarium.annotators;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Instant;
+
+import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashType;
+import com.alvarium.sign.KeyInfo;
+import com.alvarium.sign.SignException;
+import com.alvarium.sign.SignProvider;
+import com.alvarium.sign.SignProviderFactory;
+import com.alvarium.sign.SignatureInfo;
+import com.alvarium.utils.Encoder;
+import com.alvarium.utils.PropertyBag;
+
+public class PkiAnnotator extends AnnotatorUtils implements Annotator{
+  private final HashType hash;
+  private final SignatureInfo signature;
+  private final AnnotationType kind;
+
+  protected PkiAnnotator(HashType hash, SignatureInfo signature) {
+    this.hash = hash;
+    this.signature = signature;
+    this.kind = AnnotationType.PKI;
+  }
+
+  public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
+    final String key = super.deriveHash(hash, data);
+    
+    String host;
+    try {
+      host = InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      throw new AnnotatorException("Cannot get host name", e);
+    }  
+
+    final Signable signable = Signable.fromJson(new String(data));
+
+    Boolean isSatisfied = verifySignature(signature.getPublicKey(), signable);
+    
+    final Annotation annotation = new Annotation(
+        key, 
+        hash, 
+        host, 
+        kind, 
+        null, 
+        isSatisfied, 
+        Instant.now());
+
+    final String annotationSignature = super.signAnnotation(signature.getPrivateKey(), annotation);
+    annotation.setSignature(annotationSignature);
+    return annotation;
+
+  }
+  
+  /**
+   * Responsible for verifying the signature, returns true if the verification passed, false 
+   * otherwise.
+   * 
+   * 
+   * @param key The public key used to verify the signature
+   * @param signable Contains the data (seed) and signature
+   * @return True if signature valid, false otherwise
+   * @throws AnnotatorException
+   */
+  private Boolean verifySignature(KeyInfo key, Signable signable) throws AnnotatorException {
+    final SignProviderFactory signFactory = new SignProviderFactory();
+    final SignProvider signProvider;
+    try {
+      signProvider = signFactory.getProvider(key.getType());
+    } catch(SignException e) {
+      throw new AnnotatorException("Could not instantiate signing provider", e);
+    }
+
+    try {
+      // Load public key
+      final String publicKeyPath = key.getPath();
+      final String publicKey = Files.readString(
+          Paths.get(publicKeyPath), 
+          StandardCharsets.US_ASCII);
+
+      // Verify signature
+      signProvider.verify(
+          Encoder.hexToBytes(publicKey), 
+          signable.getSeed().getBytes(), 
+          Encoder.hexToBytes(signable.getSignature()));
+
+      return true;
+    } catch(SignException e) {
+        return false;     
+    } catch(IOException e) {
+      throw new AnnotatorException("Failed to load public key", e);
+    }
+
+  }
+}

--- a/src/main/java/com/alvarium/annotators/Signable.java
+++ b/src/main/java/com/alvarium/annotators/Signable.java
@@ -1,0 +1,36 @@
+package com.alvarium.annotators;
+
+import java.io.Serializable;
+
+import com.google.gson.Gson;
+
+/**
+ * A Java bean that holds the seed (data) and signature for this data
+ */
+class Signable implements Serializable {
+  private final String seed;
+  private final String signature;
+
+  protected Signable(String seed, String signature) {
+    this.seed = seed;
+    this.signature = signature;
+  }
+
+  protected String getSeed() {
+    return this.seed;
+  }
+
+  protected String getSignature() {
+    return this.signature;
+  }
+
+  protected static Signable fromJson(String json) {
+    final Gson gson = new Gson();
+    return gson.fromJson(json, Signable.class);
+  }
+
+  protected String toJson() {
+    final Gson gson = new Gson();
+    return gson.toJson(this);
+  }
+}

--- a/src/main/java/com/alvarium/contracts/AnnotationType.java
+++ b/src/main/java/com/alvarium/contracts/AnnotationType.java
@@ -8,5 +8,7 @@ public enum AnnotationType {
   @SerializedName(value = "mock")
   MOCK,
   @SerializedName(value = "tls")
-  TLS;
+  TLS,
+  @SerializedName(value = "pki")
+  PKI;
 }

--- a/src/test/java/com/alvarium/annotators/PkiAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/PkiAnnotatorTest.java
@@ -1,0 +1,69 @@
+package com.alvarium.annotators;
+
+import java.util.HashMap;
+
+import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashType;
+import com.alvarium.sign.KeyInfo;
+import com.alvarium.sign.SignType;
+import com.alvarium.sign.SignatureInfo;
+import com.alvarium.utils.ImmutablePropertyBag;
+import com.alvarium.utils.PropertyBag;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PkiAnnotatorTest {
+  @Test
+  public void executeShouldGetSatisfiedAnnotation() throws AnnotatorException {
+    final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
+    final KeyInfo pubKey = new KeyInfo("./src/test/java/com/alvarium/annotators/public.key", 
+        SignType.Ed25519);
+    final KeyInfo privKey = new KeyInfo("./src/test/java/com/alvarium/annotators/private.key",
+        SignType.Ed25519);
+    final SignatureInfo sigInfo = new SignatureInfo(pubKey, privKey);
+
+    final PropertyBag ctx = new ImmutablePropertyBag(new HashMap<String, Object>());
+
+    final String signature = "B9E41596541933DB7144CFBF72105E4E53F9493729CA66331A658B1B18AC6DF5DA991"
+        +"AD9720FD46A664918DFC745DE2F4F1F8C29FF71209B2DA79DFD1A34F50C";
+
+    final byte[] data = String.format("{seed: \"helloo\", signature: \"%s\"}", signature)
+        .getBytes();
+
+    final Annotator annotator = annotatorFactory.getAnnotator(
+        AnnotationType.PKI, 
+        HashType.SHA256Hash,
+        sigInfo);
+    final Annotation annotation = annotator.execute(ctx, data);
+    assertTrue("isSatisfied should be true", annotation.getIsSatisfied());
+  }
+
+  @Test
+  public void executeShouldGetUnsatisfiedAnnotation() throws AnnotatorException {
+    final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
+    final KeyInfo pubKey = new KeyInfo("./src/test/java/com/alvarium/annotators/public.key", 
+        SignType.Ed25519);
+    final KeyInfo privKey = new KeyInfo("./src/test/java/com/alvarium/annotators/private.key",
+        SignType.Ed25519);
+    final SignatureInfo sigInfo = new SignatureInfo(pubKey, privKey);
+
+    final PropertyBag ctx = new ImmutablePropertyBag(new HashMap<String, Object>());
+
+    final String signature = "A9E41596541933DB7144CFBF72105E4E53F9493729CA66331A658B1B18AC6DF5DA991"
+        +"AD9720FD46A664918DFC745DE2F4F1F8C29FF71209B2DA79DFD1A34F50C";
+
+    final byte[] data = String.format("{seed: \"helloo\", signature: \"%s\"}", signature)
+        .getBytes();
+
+    final Annotator annotator = annotatorFactory.getAnnotator(
+        AnnotationType.PKI, 
+        HashType.SHA256Hash,
+        sigInfo);
+    final Annotation annotation = annotator.execute(ctx, data);
+    assertFalse("isSatisfied should be false", annotation.getIsSatisfied());
+  }
+}


### PR DESCRIPTION
Fix #48

* Add signable java bean
* Create private method on PKI annotator for verifying signatures
* Implement unit tests for the annotator

Signed-off-by: Ali Amin <ali.m.amin98@gmail.com>