### PR TITLE
Implement the create() method of sdk interface

### DIFF
--- a/src/main/java/com/alvarium/Sdk.java
+++ b/src/main/java/com/alvarium/Sdk.java
@@ -1,11 +1,19 @@
 package com.alvarium;
 
+import com.alvarium.annotators.AnnotatorException;
 import com.alvarium.streams.StreamException;
 import com.alvarium.utils.PropertyBag;
 
 public interface Sdk {
-  
-  public void create(PropertyBag properties, byte[] data);
+  /**
+   * Annotates incoming data based on the list of annotators that was provided to the sdk and
+   * publishes it to the given StreamProvider.
+   * @param properties : A property bag that may be used by specific annotators
+   * @param data : data being annotated
+   * @throws AnnotatorException
+   * @throws StreamException
+   */
+  public void create(PropertyBag properties, byte[] data) throws AnnotatorException, StreamException;
   public void mutate(PropertyBag properties, byte[] oldData, byte[] newData);
   public void transit(PropertyBag properties, byte[] data);
   public void close() throws StreamException;

--- a/src/test/java/com/alvarium/SdkTest.java
+++ b/src/test/java/com/alvarium/SdkTest.java
@@ -60,7 +60,7 @@ public class SdkTest {
   }
 
   @Test
-  public void createShouldReturnSameData() {
+  public void createShouldReturnSameData() throws AnnotatorException, StreamException {
     final Sdk sdk = new MockSdk();
     final PropertyBag properties = new ImmutablePropertyBag(new HashMap<String,Object>());
     byte[] oldData = {0xA, 0x1};
@@ -68,5 +68,31 @@ public class SdkTest {
     sdk.create(properties, oldData);
     sdk.mutate(properties, oldData, newData);
     sdk.transit(properties, oldData);
+  }
+
+  @Test
+  public void defaultSdkShouldCreateAnnotations() throws AnnotatorException, StreamException {
+    final SdkInfo sdkInfo = SdkInfo.fromJson(this.testJson);
+
+    // init annotators
+    final Annotator[] annotators = new Annotator[sdkInfo.getAnnotators().length]; 
+    final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
+
+    for (int i = 0; i < annotators.length; i++) {
+      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo.getHash()
+          .getType(), sdkInfo.getSignature());
+    }
+
+    // init logger and sdk
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
+    final Sdk sdk = new DefaultSdk(annotators, sdkInfo, logger);
+
+    // init property bag and data
+    final PropertyBag properties = new ImmutablePropertyBag(new HashMap<String, Object>());
+    final byte[] data = "test data".getBytes();
+
+    sdk.create(properties, data);
+    sdk.close();
   }
 }

--- a/src/test/java/com/alvarium/mock-info.json
+++ b/src/test/java/com/alvarium/mock-info.json
@@ -1,6 +1,6 @@
 
 {
-  "annotators": ["tls", "mock"],
+  "annotators": ["mock", "mock"],
   "hash": {
     "type": "sha256"
   },


### PR DESCRIPTION
* modify the create method on the sdk interface to throw
  annotator and stream exceptions
* implement the create method on the DefaultSdk
* implement related unit tests

Fix #56

Signed-off-by: Karim Elghamry <karimelghamry@gmail.com>