### PR TITLE
Remove MQTT unit tests that depended on an available endpoint

### DIFF
--- a/src/test/java/com/alvarium/streams/MqttStreamProviderTest.java
+++ b/src/test/java/com/alvarium/streams/MqttStreamProviderTest.java
@@ -1,5 +1,8 @@
 package com.alvarium.streams;
 
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -9,17 +12,34 @@ import com.alvarium.SdkAction;
 
 import org.junit.Test;
 
+/**
+ * Tests for connecting with the MQTT broker are not annotated with `@Test` so these tests do not 
+ * run during unit testing. This is because no MQTT endpoint is guranteed in the build pipeline for
+ * the SDK.
+ * 
+ * This class does include tests for loading MQTT configuration
+ */
 public class MqttStreamProviderTest {
-  final StreamInfo info;
   
-  public MqttStreamProviderTest() throws Exception {
-    String path = "./src/test/java/com/alvarium/streams/mqtt-config.json";
-    String testJson = Files.readString(Paths.get(path), StandardCharsets.US_ASCII);
-    info = StreamInfo.fromJson(testJson);
+  // Test that the config-loaded configuration can actually be casted to MqttConfig type
+  @Test
+  public void mqttShouldLoadConfig() throws StreamException {
+    final String path = "./src/test/java/com/alvarium/streams/mqtt-config.json";
+    final String testJson;
+    try {
+      testJson  = Files.readString(Paths.get(path), StandardCharsets.US_ASCII);
+    } catch(IOException e) {
+      throw new StreamException("Could not read configuration file", e);
+    }
+    final StreamInfo info = StreamInfo.fromJson(testJson);
+    final MqttConfig config = MqttConfig.class.cast(info.getConfig());
+    assertNotNull(config);
   }
 
-  @Test
-  public void mqttShouldPublish() throws StreamException {
+  public void mqttShouldPublish() throws Exception {
+    String path = "./src/test/java/com/alvarium/streams/mqtt-config.json";
+    String testJson = Files.readString(Paths.get(path), StandardCharsets.US_ASCII);
+    StreamInfo info = StreamInfo.fromJson(testJson);
     StreamProviderFactory factory = new StreamProviderFactory();
     StreamProvider mqttProvider =  factory.getProvider(info);
     String msg = "hello";
@@ -27,15 +47,19 @@ public class MqttStreamProviderTest {
     mqttProvider.publish(wrapper);
   }
 
-  @Test
-  public void mqttShouldConnect() throws StreamException {
+  public void mqttShouldConnect() throws Exception {
+    String path = "./src/test/java/com/alvarium/streams/mqtt-config.json";
+    String testJson = Files.readString(Paths.get(path), StandardCharsets.US_ASCII);
+    StreamInfo info = StreamInfo.fromJson(testJson);
     StreamProviderFactory factory = new StreamProviderFactory();
     StreamProvider mqttProvider =  factory.getProvider(info);
     mqttProvider.connect();
   }
 
-  @Test
   public void mqttShouldClose() throws Exception {
+    String path = "./src/test/java/com/alvarium/streams/mqtt-config.json";
+    String testJson = Files.readString(Paths.get(path), StandardCharsets.US_ASCII);
+    StreamInfo info = StreamInfo.fromJson(testJson);
     StreamProviderFactory factory = new StreamProviderFactory();
     StreamProvider mqttProvider =  factory.getProvider(info);
     mqttProvider.connect();


### PR DESCRIPTION
Fix #66

* Removed `MqttStreamProvider` unit tests that required an available MQTT endpoint
* Added unit tests which ensure that the stream configuration is loaded does not fail when casting to `MqttConfig`

Signed-off-by: Ali Amin <ali.m.amin98@gmail.com>