### PR TITLE
Change abstract class name AnnotatorUtils to AbstractAnnotator

### DIFF
--- a/src/main/java/com/alvarium/annotators/AnnotatorUtils.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorUtils.java
@@ -19,7 +19,7 @@ import com.alvarium.utils.Encoder;
 /**
  * A Util class responsible for carrying out common operations done by the annotators
  */
-abstract class AnnotatorUtils {
+abstract class AbstractAnnotator {
 
   /**
    * returns hash of the provided data depending on the given hash type

--- a/src/main/java/com/alvarium/annotators/PkiAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/PkiAnnotator.java
@@ -19,7 +19,7 @@ import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.Encoder;
 import com.alvarium.utils.PropertyBag;
 
-class PkiAnnotator extends AnnotatorUtils implements Annotator {
+class PkiAnnotator extends AbstractAnnotator implements Annotator {
   private final HashType hash;
   private final SignatureInfo signature;
   private final AnnotationType kind;

--- a/src/main/java/com/alvarium/annotators/SourceAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/SourceAnnotator.java
@@ -14,7 +14,7 @@ import com.alvarium.utils.PropertyBag;
  * A unit used to provide lineage from one version of data to another as a result of
  * change or transformation
  */
-class SourceAnnotator extends AnnotatorUtils implements Annotator {
+class SourceAnnotator extends AbstractAnnotator implements Annotator {
   private final HashType hash;
   private final AnnotationType kind;
   private final SignatureInfo signatureInfo;

--- a/src/main/java/com/alvarium/annotators/TlsAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/TlsAnnotator.java
@@ -11,7 +11,7 @@ import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.PropertyBag;
 
-class TlsAnnotator extends AnnotatorUtils implements Annotator {
+class TlsAnnotator extends AbstractAnnotator implements Annotator {
   private final HashType hash;
   private final AnnotationType kind;
   private final SignatureInfo signatureInfo;

--- a/src/main/java/com/alvarium/annotators/TpmAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/TpmAnnotator.java
@@ -14,7 +14,7 @@ import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.PropertyBag;
 
-class TpmAnnotator extends AnnotatorUtils implements Annotator {
+class TpmAnnotator extends AbstractAnnotator implements Annotator {
   private final HashType hash;
   private final AnnotationType kind;
   private final SignatureInfo signature;


### PR DESCRIPTION
Fix #58

* Changed the name of `AnnotatorUtils` to `AbstractAnnotator` so that it follows the Java naming convention for abstract classes

Signed-off-by: Ali Amin <ali.m.amin98@gmail.com>