### PR TITLE
Overload SDK methods for reduced boilerplate

### DIFF
--- a/src/main/java/com/alvarium/DefaultSdk.java
+++ b/src/main/java/com/alvarium/DefaultSdk.java
@@ -1,6 +1,7 @@
 package com.alvarium;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import com.alvarium.annotators.Annotator;
@@ -11,6 +12,7 @@ import com.alvarium.contracts.AnnotationType;
 import com.alvarium.streams.StreamException;
 import com.alvarium.streams.StreamProvider;
 import com.alvarium.streams.StreamProviderFactory;
+import com.alvarium.utils.ImmutablePropertyBag;
 import com.alvarium.utils.PropertyBag;
 
 import org.apache.logging.log4j.Logger;
@@ -48,6 +50,11 @@ public class DefaultSdk implements Sdk {
     this.stream.publish(wrapper);
     this.logger.debug("data annotated and published successfully.");
   }
+  
+  public void create(byte[] data) throws AnnotatorException, StreamException {
+    final PropertyBag properties = new ImmutablePropertyBag(new HashMap<String, Object>());
+    this.create(properties, data);
+  }
 
   public void mutate(PropertyBag properties, byte[] oldData, byte[] newData) throws 
   AnnotatorException, StreamException {
@@ -71,6 +78,11 @@ public class DefaultSdk implements Sdk {
     this.logger.debug("data annotated and published successfully.");
   }
 
+  public void mutate(byte[] oldData, byte[] newData) throws AnnotatorException, StreamException {
+    final PropertyBag properties = new ImmutablePropertyBag(new HashMap<String, Object>());
+    this.mutate(properties, oldData, newData);
+  }
+
   public void transit(PropertyBag properties, byte[] data) throws AnnotatorException,
       StreamException {
     final List<Annotation> annotations = new ArrayList<Annotation>();
@@ -86,6 +98,11 @@ public class DefaultSdk implements Sdk {
     final PublishWrapper wrapper = new PublishWrapper(SdkAction.TRANSIT, contentType, annotations);
     this.stream.publish(wrapper);
     this.logger.debug("data annotated and published successfully.");
+  }
+
+  public void transit(byte[] data) throws AnnotatorException, StreamException {
+    final PropertyBag properties = new ImmutablePropertyBag(new HashMap<String, Object>());
+    this.transit(properties, data);
   }
 
   public void close() throws StreamException {

--- a/src/main/java/com/alvarium/Sdk.java
+++ b/src/main/java/com/alvarium/Sdk.java
@@ -8,24 +8,58 @@ public interface Sdk {
   /**
    * Annotates incoming data based on the list of annotators that was provided to the sdk and
    * publishes it to the given StreamProvider.
-   * @param properties : A property bag that may be used by specific annotators
+   * 
+   * @param properties : A property bag that may be used by specific (or custom) annotators to pass
+   * custom values to them. The built-in annotators that require custom values are
+   * <ul>
+   * <li>TLS: Takes a key-value pair of "TLS": Socket</li>
+   * </ul>
    * @param data : data being annotated
    * @throws AnnotatorException
    * @throws StreamException
    */
-  public void create(PropertyBag properties, byte[] data) throws AnnotatorException, StreamException;
+  public void create(PropertyBag properties, byte[] data) 
+      throws AnnotatorException, StreamException;
+
+  /**
+   * Annotates incoming data based on the list of annotators that was provided to the sdk and 
+   * publishes it to the given StreamProvider.
+   * @param data : data being annotated
+   * @throws AnnotatorException
+   * @throws StreamException
+   */
+  public void create(byte[] data) throws AnnotatorException, StreamException;
+
   /**
    * Used when the recieved piece of data is originated by a separate application.
    * The data is being transitioned from one application to another.
-   * @param properties : property bag for potential use by the annotators
+   * @param properties : A property bag that may be used by specific (or custom) annotators to pass
+   * custom values to them. The built-in annotators that require custom values are
+   * <ul>
+   * <li>TLS: Takes a key-value pair of "TLS": Socket</li>
+   * </ul>
    * @param data : data being annotated
    * @throws AnnotatorException
    * @throws StreamException
    */
-  public void transit(PropertyBag properties, byte[] data) throws AnnotatorException, StreamException;
+  public void transit(PropertyBag properties, byte[] data) 
+      throws AnnotatorException, StreamException;
+
+  /**
+   * Used when the recieved piece of data is originated by a separate application.
+   * The data is being transitioned from one application to another.
+   * @param data
+   * @throws AnnotatorException
+   * @throws StreamException
+   */
+  public void transit(byte[] data) throws AnnotatorException, StreamException;
   /**
    * Handles annotations related to any type of data modification.
-   * @param properties : property bag for potential use by the annotators
+   * @param properties : A property bag that may be used by specific (or custom) annotators to pass
+   * custom values to them. The built-in annotators that require custom values are
+   * <ul>
+   * <li>TLS: Takes a key-value pair of "TLS": Socket</li>
+   * </ul>
    * @param oldData : original data
    * @param newData : incoming new data
    * @throws AnnotatorException
@@ -33,5 +67,16 @@ public interface Sdk {
    */
   public void mutate(PropertyBag properties, byte[] oldData, byte[] newData) throws 
       AnnotatorException, StreamException;
+
+  /**
+   * Handles annotations related to any type of data modification.
+   * @throws StreamException
+   */
+  public void mutate(byte[] oldData, byte[] newData) throws AnnotatorException, StreamException;
+
+  /**
+   * Closes any open connections 
+   * @throws StreamException
+   */
   public void close() throws StreamException;
 }

--- a/src/test/java/com/alvarium/SdkTest.java
+++ b/src/test/java/com/alvarium/SdkTest.java
@@ -20,11 +20,20 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.Test;
 
 class MockSdk implements Sdk {
-  public void create(PropertyBag properties, byte[] data) {
+  public void create(PropertyBag properties, byte[] data) {}
+  public void create(byte[] data) {
+    final PropertyBag properties = new ImmutablePropertyBag(new HashMap<String, Object>());
+    this.create(properties, data);
   }
-  public void mutate(PropertyBag properties, byte[] oldData, byte[] newData) {
+  public void mutate(PropertyBag properties, byte[] oldData, byte[] newData) {}
+  public void mutate(byte[] oldData, byte[] newData) {
+    final PropertyBag properties = new ImmutablePropertyBag(new HashMap<String, Object>());
+    this.mutate(properties, oldData, newData);
   }
-  public void transit(PropertyBag properties, byte[] data) {
+  public void transit(PropertyBag properties, byte[] data) {}
+  public void transit(byte[] data) {
+    final PropertyBag properties = new ImmutablePropertyBag(new HashMap<String, Object>());
+    this.transit(properties, data);
   }
   public void close() {
     System.out.println("Connections closed");
@@ -62,12 +71,11 @@ public class SdkTest {
   @Test
   public void createShouldReturnSameData() throws AnnotatorException, StreamException {
     final Sdk sdk = new MockSdk();
-    final PropertyBag properties = new ImmutablePropertyBag(new HashMap<String,Object>());
     byte[] oldData = {0xA, 0x1};
     byte[] newData = {0x1, 0xA};
-    sdk.create(properties, oldData);
-    sdk.mutate(properties, oldData, newData);
-    sdk.transit(properties, oldData);
+    sdk.create(oldData);
+    sdk.mutate(oldData, newData);
+    sdk.transit(oldData);
   }
 
   @Test
@@ -88,11 +96,9 @@ public class SdkTest {
     Configurator.setRootLevel(Level.DEBUG);
     final Sdk sdk = new DefaultSdk(annotators, sdkInfo, logger);
 
-    // init property bag and data
-    final PropertyBag properties = new ImmutablePropertyBag(new HashMap<String, Object>());
     final byte[] data = "test data".getBytes();
 
-    sdk.create(properties, data);
+    sdk.create(data);
     sdk.close();
   }
 
@@ -115,10 +121,9 @@ public class SdkTest {
     Configurator.setRootLevel(Level.DEBUG);
     final Sdk sdk = new DefaultSdk(annotators, sdkInfo, logger);
 
-    final PropertyBag properties = new ImmutablePropertyBag(new HashMap<String, Object>());
     final byte[] data = "test data".getBytes();
 
-    sdk.transit(properties, data);
+    sdk.transit(data);
     sdk.close();
   }
 
@@ -140,12 +145,11 @@ public class SdkTest {
     Configurator.setRootLevel(Level.DEBUG);
     final Sdk sdk = new DefaultSdk(annotators, sdkInfo, logger);
 
-    // init property bag and data
-    final PropertyBag properties = new ImmutablePropertyBag(new HashMap<String, Object>());
+
     final byte[] oldData = "old data".getBytes();
     final byte[] newData = "new data".getBytes();
 
-    sdk.mutate(properties, oldData, newData);
+    sdk.mutate(oldData, newData);
     sdk.close();
   }
 }


### PR DESCRIPTION
Fix #67

* Overload SDK methods to be able to call them without passing a property bag

Signed-off-by: Ali Amin <ali.m.amin98@gmail.com>