### PR TITLE
Make SdkInfo a dependency for AnnotatorsFactory

### DIFF
--- a/src/main/java/com/alvarium/DefaultSdk.java
+++ b/src/main/java/com/alvarium/DefaultSdk.java
@@ -54,7 +54,7 @@ public class DefaultSdk implements Sdk {
     // source annotate the old data
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
     final Annotator sourceAnnotator = annotatorFactory.getAnnotator(AnnotationType.SOURCE,
-        this.config.getHash().getType(), this.config.getSignature());
+        this.config);
     final Annotation sourceAnnotation = sourceAnnotator.execute(properties, oldData);
     annotations.add(sourceAnnotation);
 

--- a/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
@@ -1,13 +1,15 @@
 package com.alvarium.annotators;
 
+import com.alvarium.SdkInfo;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
 
 public class AnnotatorFactory {
 
-  public Annotator getAnnotator(AnnotationType kind, HashType hash, SignatureInfo signature) 
-      throws AnnotatorException {
+  public Annotator getAnnotator(AnnotationType kind, SdkInfo config) throws AnnotatorException {
+    final HashType hash = config.getHash().getType();
+    final SignatureInfo signature = config.getSignature();
     switch (kind) {
       case MOCK:
         return new MockAnnotator(hash, kind, signature);

--- a/src/test/java/com/alvarium/SdkTest.java
+++ b/src/test/java/com/alvarium/SdkTest.java
@@ -56,8 +56,7 @@ public class SdkTest {
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
 
     for (int i = 0; i < annotators.length; i++) {
-      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo.getHash()
-          .getType(), sdkInfo.getSignature());
+      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo);
     }
 
     // init logger
@@ -87,8 +86,7 @@ public class SdkTest {
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
 
     for (int i = 0; i < annotators.length; i++) {
-      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo.getHash()
-          .getType(), sdkInfo.getSignature());
+      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo); 
     }
 
     // init logger and sdk
@@ -112,8 +110,7 @@ public class SdkTest {
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
 
     for (int i = 0; i < annotators.length; i++) {
-      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo.getHash()
-          .getType(), sdkInfo.getSignature());
+      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo); 
     }
 
     // init logger and sdk
@@ -136,8 +133,7 @@ public class SdkTest {
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
 
     for (int i = 0; i < annotators.length; i++) {
-      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo.getHash()
-      .getType(), sdkInfo.getSignature());
+      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo); 
     }
 
     // init logger and sdk

--- a/src/test/java/com/alvarium/annotators/AnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/AnnotatorTest.java
@@ -2,8 +2,10 @@ package com.alvarium.annotators;
 
 import java.util.HashMap;
 
+import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
@@ -18,9 +20,10 @@ public class AnnotatorTest {
   public void mockAnnotatorShouldReturnAnnotation() throws AnnotatorException {
     final KeyInfo keyInfo = new KeyInfo("path", SignType.none);
     final SignatureInfo signature = new SignatureInfo(keyInfo, keyInfo);
+    final AnnotationType[] annotators = {};
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.NoHash), signature, null);
     final AnnotatorFactory factory = new AnnotatorFactory();
-    final Annotator annotator = factory.getAnnotator(AnnotationType.MOCK, HashType.MD5Hash,
-        signature);
+    final Annotator annotator = factory.getAnnotator(AnnotationType.MOCK, config);
     final byte[] data = "test data".getBytes();
     final PropertyBag ctx = new ImmutablePropertyBag(new HashMap<>());
     final Annotation annotation = annotator.execute(ctx, data);

--- a/src/test/java/com/alvarium/annotators/PkiAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/PkiAnnotatorTest.java
@@ -2,8 +2,10 @@ package com.alvarium.annotators;
 
 import java.util.HashMap;
 
+import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
@@ -34,10 +36,9 @@ public class PkiAnnotatorTest {
     final byte[] data = String.format("{seed: \"helloo\", signature: \"%s\"}", signature)
         .getBytes();
 
-    final Annotator annotator = annotatorFactory.getAnnotator(
-        AnnotationType.PKI, 
-        HashType.SHA256Hash,
-        sigInfo);
+    final AnnotationType[] annotators = {AnnotationType.PKI};
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKI, config);
     final Annotation annotation = annotator.execute(ctx, data);
     assertTrue("isSatisfied should be true", annotation.getIsSatisfied());
   }
@@ -59,10 +60,10 @@ public class PkiAnnotatorTest {
     final byte[] data = String.format("{seed: \"helloo\", signature: \"%s\"}", signature)
         .getBytes();
 
-    final Annotator annotator = annotatorFactory.getAnnotator(
-        AnnotationType.PKI, 
-        HashType.SHA256Hash,
-        sigInfo);
+    final AnnotationType[] annotators = {AnnotationType.PKI};
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKI, config);
+
     final Annotation annotation = annotator.execute(ctx, data);
     assertFalse("isSatisfied should be false", annotation.getIsSatisfied());
   }

--- a/src/test/java/com/alvarium/annotators/SourceAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/SourceAnnotatorTest.java
@@ -3,8 +3,10 @@ package com.alvarium.annotators;
 import java.io.IOException;
 import java.util.HashMap;
 
+import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
@@ -24,8 +26,10 @@ public class SourceAnnotatorTest {
     final KeyInfo privKey = new KeyInfo("./src/test/java/com/alvarium/annotators/private.key",
         SignType.Ed25519);
     final SignatureInfo sigInfo = new SignatureInfo(pubKey, privKey);
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.SOURCE,
-        HashType.SHA256Hash, sigInfo);
+    final AnnotationType[] annotators = { AnnotationType.SOURCE };
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+
+    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.SOURCE, config);
 
     // dummy data and empty prop bag
     final byte[] data = "test data".getBytes();

--- a/src/test/java/com/alvarium/annotators/TlsAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/TlsAnnotatorTest.java
@@ -7,8 +7,10 @@ import java.util.HashMap;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
+import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
@@ -30,8 +32,9 @@ public class TlsAnnotatorTest {
     final KeyInfo privKey = new KeyInfo("./src/test/java/com/alvarium/annotators/private.key",
         SignType.Ed25519);
     final SignatureInfo sigInfo = new SignatureInfo(pubKey, privKey);
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.TLS, HashType.SHA256Hash,
-        sigInfo);
+    final AnnotationType[] annotators = { AnnotationType.TLS };
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.TLS, config); 
     
     // dummy data
     final byte[] data = "test data".getBytes();

--- a/src/test/java/com/alvarium/annotators/TpmAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/TpmAnnotatorTest.java
@@ -2,8 +2,10 @@ package com.alvarium.annotators;
 
 import java.util.HashMap;
 
+import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
@@ -26,7 +28,9 @@ public class TpmAnnotatorTest {
         SignType.Ed25519);
 
     SignatureInfo sign = new SignatureInfo(publicKey, privateKey);
-    Annotator tpm = factory.getAnnotator(AnnotationType.TPM, HashType.MD5Hash, sign);
+    final AnnotationType[] annotators = { AnnotationType.TPM };
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
+    Annotator tpm = factory.getAnnotator(AnnotationType.TPM, config);
     
     PropertyBag ctx = new ImmutablePropertyBag(new HashMap<String, Object>());
     


### PR DESCRIPTION
* Change annotators factory depedencies to be
  AnnotationType and SdkInfo
* Fix all related unit tests

Fix #77

Signed-off-by: Karim Elghamry <karimelghamry@gmail.com>