### PR TITLE
Make the published messages conform with the Go SDK's messages

### DIFF
--- a/src/main/java/com/alvarium/DefaultSdk.java
+++ b/src/main/java/com/alvarium/DefaultSdk.java
@@ -22,6 +22,7 @@ import com.alvarium.annotators.Annotator;
 import com.alvarium.annotators.AnnotatorException;
 import com.alvarium.annotators.AnnotatorFactory;
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationList;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.streams.StreamException;
 import com.alvarium.streams.StreamProvider;
@@ -137,10 +138,14 @@ public class DefaultSdk implements Sdk {
    */
   private void publishAnnotations(SdkAction action, List<Annotation> annotations) 
       throws StreamException {
-    final String contentType = "AnnotationList";
-
+    final AnnotationList annotationList = new AnnotationList(annotations);
+    
     // publish list of annotations to the StreamProvider
-    final PublishWrapper wrapper = new PublishWrapper(action, contentType, annotations);
+    final PublishWrapper wrapper = new PublishWrapper(
+        action, 
+        annotationList.getClass().getName(), 
+        annotationList
+    );
     this.stream.publish(wrapper);
   }
 }

--- a/src/main/java/com/alvarium/PublishWrapper.java
+++ b/src/main/java/com/alvarium/PublishWrapper.java
@@ -15,11 +15,13 @@
 package com.alvarium;
 
 import java.io.Serializable;
+import java.util.Base64;
 
 import com.alvarium.contracts.Annotation;
 import com.alvarium.serializers.AnnotationConverter;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 
 /**
  * A java bean that encapsulates the content sent through the stream providers
@@ -48,15 +50,33 @@ public class PublishWrapper implements Serializable {
     return content;
   }
 
-  public static PublishWrapper fromJson(String json) {
-    Gson gson = new GsonBuilder().registerTypeAdapter(Annotation.class, new AnnotationConverter())
-        .create();
-    return gson.fromJson(json, PublishWrapper.class);
-  }
-
+  /**
+   * The content field in the returned JSON will be Base64 string encoded 
+   * @return String representation of the PublishWrapper JSON
+   */
   public String toJson() {
-    Gson gson = new GsonBuilder().registerTypeAdapter(Annotation.class, new AnnotationConverter())
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapter(Annotation.class, new AnnotationConverter())
+        .disableHtmlEscaping()
         .create();
-    return gson.toJson(this);
+    
+    // Change the content field to a base64 encoded string before serializing to json
+    final JsonElement decodedContent = gson.toJsonTree(this.content);
+    final String encodedContent;
+    
+    // `toString()` will work if the content is a primitive type, but will add additional 
+    // quotes (e.g. "foo" will be "\"foo\"") but `getAsString()` will produce correct behavior but
+    // using `getAsString()` on a non-primitive type will throw an exception.
+    // This condition ensures that the correct method is called on the correct type
+    if (decodedContent.isJsonPrimitive()) {
+      encodedContent = Base64.getEncoder().encodeToString(decodedContent.getAsString().getBytes());
+    } else {
+      encodedContent = Base64.getEncoder().encodeToString(decodedContent.toString().getBytes());
+    }
+
+    // new publish wrapper returned as JSON string with encoded content 
+    // to prevent setting the object content value
+    final PublishWrapper wrapper = new PublishWrapper(action, messageType, encodedContent);
+    return gson.toJson(wrapper);
   }
 }

--- a/src/main/java/com/alvarium/contracts/AnnotationList.java
+++ b/src/main/java/com/alvarium/contracts/AnnotationList.java
@@ -1,0 +1,57 @@
+
+/*******************************************************************************
+ * Copyright 2021 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.alvarium.contracts;
+
+import java.util.List;
+
+import com.alvarium.serializers.AnnotationConverter;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+
+/**
+ * A wrapper over the list of annotations
+ */
+public class AnnotationList {
+  private final List<Annotation> items;
+
+  public AnnotationList(Annotation[] annotations) {
+    this.items = List.of(annotations);
+  }
+  
+  public AnnotationList(List<Annotation> annotations) {
+    this.items = annotations;
+  }
+
+  public List<Annotation> getAnnotations() {
+    return this.items;
+  }
+
+  public String toJson() {
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapter(Annotation.class, new AnnotationConverter())
+        .create();
+
+    return gson.toJson(this);
+  }
+
+  public static AnnotationList fromJson(String json) {
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapter(Annotation.class, new AnnotationConverter())
+        .create();
+    
+    return gson.fromJson(json, AnnotationList.class);
+  }
+}

--- a/src/main/java/com/alvarium/serializers/AnnotationConverter.java
+++ b/src/main/java/com/alvarium/serializers/AnnotationConverter.java
@@ -32,6 +32,6 @@ public class AnnotationConverter implements JsonSerializer<Annotation>, JsonDese
   }
 
   public Annotation deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
-    return Annotation.fromJson(json.getAsString());
+    return Annotation.fromJson(json.toString());
   }
 }

--- a/src/test/java/com/alvarium/PublishWrapperTest.java
+++ b/src/test/java/com/alvarium/PublishWrapperTest.java
@@ -14,17 +14,13 @@
  *******************************************************************************/
 package com.alvarium;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationList;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
 
@@ -46,22 +42,21 @@ public class PublishWrapperTest {
   public void toJsonShouldParseAnnotationCorrectly() {
     final SdkAction action = SdkAction.CREATE;
     final String messageType = "test type";
-    final Annotation annotation = new Annotation("key", HashType.MD5Hash, "host", AnnotationType.TPM
-        , "signature", true, Instant.now());
-
-    final Annotation[] annotationList = {annotation, annotation};    
-    final PublishWrapper wrapper = new PublishWrapper(action, messageType, annotationList);
+    final Annotation annotation = new Annotation(
+      "key", 
+      HashType.MD5Hash, 
+      "host", 
+      AnnotationType.TPM, 
+      "signature", 
+      true, 
+      Instant.now()
+    );
+    final List<Annotation> annotations = List.of(annotation, annotation);
+    final PublishWrapper wrapper = new PublishWrapper(
+        action,
+        messageType, 
+        new AnnotationList(annotations)
+    );
     System.out.println(wrapper.toJson());
   }
-
-  @Test
-  public void fromJsonShouldReturnAppropriateObject() throws IOException {
-    String path = "./src/test/java/com/alvarium/publishWrapperData.json";
-    final String testJson = Files.readString(Paths.get(path), StandardCharsets.US_ASCII);
-
-    final PublishWrapper wrapper = PublishWrapper.fromJson(testJson);
-    assertEquals(SdkAction.CREATE, wrapper.getAction());
-    assertEquals("test type", wrapper.getMessageType()); 
-    assertEquals("test content", wrapper.getContent());
-   }
 }

--- a/src/test/java/com/alvarium/contracts/AnnotationListTest.java
+++ b/src/test/java/com/alvarium/contracts/AnnotationListTest.java
@@ -1,0 +1,67 @@
+
+/*******************************************************************************
+ * Copyright 2021 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.alvarium.contracts;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+
+import com.alvarium.hash.HashType;
+
+import org.junit.Test;
+
+public class AnnotationListTest {
+  
+  @Test
+  public void toJsonShouldParseCorrectly() {
+    final Annotation annotation = new Annotation(
+      "key", 
+      HashType.NoHash,
+      "host", 
+      AnnotationType.MOCK, 
+      "signature", 
+      true, 
+      Instant.now()
+    );
+    final AnnotationList annotations = new AnnotationList(List.of(annotation, annotation));
+    System.out.println(annotations.toJson());
+  }
+
+  @Test
+  public void fromJsonShouldPraseCorrectly() throws IOException {
+
+    final String annotation = "{\"id\":\"01FHX2DH740WQB4WQS6A6X21QP\","+
+    "\"key\":\"key\"," +
+    "\"hash\":\"md5\"," +
+    "\"host\":\"host\"," + 
+    "\"kind\":\"tpm\"," + 
+    "\"signature\":\"signature\"," +
+    "\"isSatisfied\":true," +
+    "\"timestamp\":\"2021-10-13T07:55:33.585017-07:00\"}";
+
+    final String annotationsJson = String.format("{\"items\": [%s,%s]}", annotation, annotation);
+    final AnnotationList annotationList = AnnotationList.fromJson(annotationsJson);
+    assertNotNull(annotationList);
+    assertNotNull(annotationList.getAnnotations());
+    assertEquals(
+      "AnnotationList initialized with incorrect items length",
+      annotationList.getAnnotations().size(),
+      2
+    ); 
+  }
+}

--- a/src/test/java/com/alvarium/publishWrapperData.json
+++ b/src/test/java/com/alvarium/publishWrapperData.json
@@ -1,5 +1,0 @@
-{
-  "action": "create",
-  "messageType": "test type",
-  "content": "test content" 
-}


### PR DESCRIPTION
Fix #82

* Add AnnotationList class
* Fix incorrect `toString()` method called in `AnnotatorConverter`'s deserialize method
* Add unit tests for `AnnotationList`
* Base64 encode content of `PublishWrapper` when calling `toJson()`
* Use `AnnotationList` in `PublishWrapper` unit tests
* Remove `fromJson()` method of `PublishWrapper` as it is out of the scope for
  this class
* Remove test json file for testing `PublishWrapper`'s `fromJson()`
* Wrap the list of annotations with the `AnnotationList` when publishing
  in the SDK methods