### PR TITLE
Bump log4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,13 +57,13 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.14.1</version>
+        <version>2.15.0</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.14.1</version>
+        <version>2.15.0</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Fix #85

* Update log4j dependency from 2.14.1 to 2.15.0

Signed-off-by: Ali Amin <ali.m.amin98@gmail.com>