### PR TITLE
Fix intermittent hanging in Encoder unit test

### DIFF
--- a/src/test/java/com/alvarium/utils/EncoderTest.java
+++ b/src/test/java/com/alvarium/utils/EncoderTest.java
@@ -16,7 +16,8 @@ public class EncoderTest {
   public void bytesToHexShouldReturnDoubleLength() throws NoSuchAlgorithmException{
     for (int i = 0; i < 20; i++) {
       byte[] data = new byte[i];
-      SecureRandom.getInstanceStrong().nextBytes(data);
+      // "NativePRNG" uses `/dev/urandom` for for `nextBytes()`
+      SecureRandom.getInstance("NativePRNG").nextBytes(data); 
       String hexResult = Encoder.bytesToHex(data);
       assertEquals(data.length * 2, hexResult.length());
     }


### PR DESCRIPTION
Fix #87

* Use "NativePRNG" to tap into `/dev/urandom` for random number generation

Signed-off-by: Ali Amin <ali.m.amin98@gmail.com>