### PR TITLE
AnnotationType source does not conform to the go sdk implementation

### DIFF
--- a/src/main/java/com/alvarium/contracts/AnnotationType.java
+++ b/src/main/java/com/alvarium/contracts/AnnotationType.java
@@ -25,6 +25,6 @@ public enum AnnotationType {
   TLS,
   @SerializedName(value = "pki")
   PKI,
-  @SerializedName(value = "source")
+  @SerializedName(value = "src")
   SOURCE;
 }


### PR DESCRIPTION
* change AnnotationType.SOURCE serialization value to "src"

Fix #91

Signed-off-by: Karim Elghamry <karim_elghamry@dell.com>