### PR TITLE
Implement the parser required to add Support for Signature Validation…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,13 +17,20 @@
     </properties>
 
     <dependencies>
+  
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
-
+        
         <dependency>
             <groupId>com.google.crypto.tink</groupId>
             <artifactId>tink</artifactId>

--- a/src/main/java/com/alvarium/annotators/http/ParseResult.java
+++ b/src/main/java/com/alvarium/annotators/http/ParseResult.java
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Copyright 2022 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.alvarium.annotators.http;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.alvarium.contracts.DerivedComponent;
+
+import org.apache.http.Header;
+import org.apache.http.client.methods.HttpUriRequest;
+
+public class ParseResult {
+  private String seed;
+  private String signature;
+  private String keyid;
+  private String algorithm;
+
+  public ParseResult(HttpUriRequest request) throws URISyntaxException, ParseResultException {
+    String signatureInput = request.getHeaders("Signature-Input")[0].getValue();
+
+    // to avoid throwing an error when the parser is called from the handler,
+    // no signature is present unlike when its called from the annotator
+    this.signature = "";
+    if (request.containsHeader("Signature")) {
+      this.signature = request.getHeaders("Signature")[0].getValue();
+    }
+
+    String[] signatureInputList = signatureInput.split(";", 2);
+    String[] signatureInputHeader = signatureInputList[0].split("\\s+");
+    String signatureInputTail = signatureInputList[1];
+    String[] signatureInputParsedTail = signatureInputTail.split(";", -1);
+
+    for (String s : signatureInputParsedTail) {
+      if (s.contains("alg")) {
+        String raw = s.split("=", -1)[1];
+        this.algorithm = raw.substring(1, raw.length() - 1);
+      }
+      if (s.contains("keyid")) {
+        String raw = s.split("=", -1)[1];
+        this.keyid = raw.substring(1, raw.length() - 1);
+      }
+    }
+
+    Map<String, String[]> signatureInputFields = new HashMap<>();
+
+    StringBuilder signatureInputBody = new StringBuilder();
+
+    for (String field : signatureInputHeader) {
+      String key = field.substring(1, field.length() - 1);
+
+      if (key.charAt(0) == '@') {
+        URI uri = request.getURI();
+        DerivedComponent derivedComponent;
+        try {
+          derivedComponent = DerivedComponent.fromString(key);
+        } catch (EnumConstantNotPresentException e) {
+          throw new ParseResultException(String.format("Unhandled Derived Component %s", key));
+        }
+        if (!uri.isAbsolute()) {
+          throw new ParseResultException("Request URI is not absolute");
+        }
+        switch (derivedComponent) {
+          case METHOD:
+            signatureInputFields.put(key, new String[] { request.getMethod() });
+            break;
+          case TARGETURI:
+            signatureInputFields.put(key, new String[] { uri.toString() });
+            break;
+          case AUTHORITY:
+            signatureInputFields.put(key, new String[] { uri.getAuthority() });
+            break;
+          case SCHEME:
+            signatureInputFields.put(key, new String[] { uri.getScheme() });
+            break;
+          case PATH:
+            signatureInputFields.put(key, new String[] { uri.getPath() });
+            break;
+          case QUERY:
+            String query = "?" + uri.getRawQuery();
+            signatureInputFields.put(key, new String[] { query });
+            break;
+          case QUERYPARAMS:
+            String[] rawQueryParams = uri.getRawQuery().split("&", -1);
+            List<String> queryParams = new ArrayList<>();
+            for (String rawQueryParam : rawQueryParams) {
+              if (rawQueryParam != "") {
+                String[] parameter = rawQueryParam.split("=", -1);
+                String name = parameter[0];
+                String value = parameter[1];
+                queryParams.add(String.format(";name=\"%s\": %s", name, value));
+              }
+            }
+            signatureInputFields.put(key, queryParams.toArray(new String[queryParams.size()]));
+        }
+      } else {
+        Header[] fieldValues = request.getHeaders(key);
+        if (fieldValues.length == 0) {
+          throw new ParseResultException(String.format("Header field not found %s", key));
+        } else {
+          StringBuilder value = new StringBuilder();
+          for (int i = 0; i < fieldValues.length - 1; i++) {
+            value.append(fieldValues[i].getValue() + ", ");
+          }
+          value.append(fieldValues[fieldValues.length - 1].getValue());
+
+          // Remove extra spaces from fieldValue
+          String fieldValue = String.join(" ", value.toString().trim().split("\\s+"));
+          signatureInputFields.put(key, new String[] { fieldValue });
+        }
+      }
+
+      // Construct final output string
+      String[] keyValues = signatureInputFields.get(key);
+      if (keyValues.length == 1) {
+        signatureInputBody.append("\"" + key + "\" " + keyValues[0] + "\n");
+      } else {
+        for (String s : keyValues) {
+          signatureInputBody.append("\"" + key + "\"" + s + "\n");
+        }
+      }
+    }
+
+    this.seed = String.format("%s;%s", signatureInputBody.toString(), signatureInputTail);
+
+    return;
+  }
+
+  public String getSeed() {
+    return this.seed;
+  }
+
+  public String getSignature() {
+    return this.signature;
+  }
+
+  public String getKeyid() {
+    return this.keyid;
+  }
+
+  public String getAlgorithm() {
+    return this.algorithm;
+  }
+}

--- a/src/main/java/com/alvarium/annotators/http/ParseResultException.java
+++ b/src/main/java/com/alvarium/annotators/http/ParseResultException.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright 2022 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.alvarium.annotators.http;
+
+/**
+ * a general exception type to be used by the ParseResult
+ */
+public class ParseResultException extends Exception {
+  public ParseResultException(String msg) {
+    super(msg);
+  }
+
+  public ParseResultException(String msg, Exception e) {
+    super(msg, e);
+  }
+}

--- a/src/main/java/com/alvarium/contracts/DerivedComponent.java
+++ b/src/main/java/com/alvarium/contracts/DerivedComponent.java
@@ -1,0 +1,54 @@
+
+/*******************************************************************************
+ * Copyright 2022 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.alvarium.contracts;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public enum DerivedComponent {
+  METHOD("@method"),
+  TARGETURI("@target-uri"),
+  AUTHORITY("@authority"),
+  SCHEME("@scheme"),
+  PATH("@path"),
+  QUERY("@query"),
+  QUERYPARAMS("@query-params");
+
+  private static final Map<String, DerivedComponent> derivedComponentMap = new HashMap<>();
+  private final String value;
+
+  private DerivedComponent(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return this.value;
+  }
+
+  static {
+    for (DerivedComponent derivedComponent : DerivedComponent.values()) {
+      derivedComponentMap.put(derivedComponent.value, derivedComponent);
+    }
+  }
+
+  public static DerivedComponent fromString(String value) throws EnumConstantNotPresentException {
+    DerivedComponent derivedComponent = derivedComponentMap.get(value);
+    if (derivedComponent != null) {
+      return derivedComponent;
+    }
+    throw new EnumConstantNotPresentException(DerivedComponent.class, value);
+  }
+}

--- a/src/test/java/com/alvarium/annotators/http/ParseResultTest.java
+++ b/src/test/java/com/alvarium/annotators/http/ParseResultTest.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright 2022 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.alvarium.annotators.http;
+
+import org.apache.http.client.methods.HttpPost;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class ParseResultTest {
+
+  HttpPost getRequest() {
+    HttpPost request = new HttpPost(URI.create("http://example.com/foo?var1=&var2=2"));
+    request.setHeader("Date", "Tue, 20 Apr 2021 02:07:55 GMT");
+    request.setHeader("Content-Type", "application/json");
+    request.setHeader("Content-Length", "18");
+    request.setHeader("Signature-Input", "");
+    request.setHeader("Signature", "whatever");
+    return request;
+  }
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Test
+  public void testIntegrationAllFields() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input",
+        "\"date\" \"@method\" \"@path\" \"@authority\" \"content-type\" \"content-length\" \"@query-params\" \"@query\" \"@target-uri\";created=1644758607;keyid=\"public.key\";alg=\"ed25519\";");
+    String expectedSeed = "\"date\" Tue, 20 Apr 2021 02:07:55 GMT\n\"@method\" POST\n\"@path\" /foo\n\"@authority\" example.com\n\"content-type\" application/json\n\"content-length\" 18\n\"@query-params\";name=\"var1\": \n\"@query-params\";name=\"var2\": 2\n\"@query\" ?var1=&var2=2\n\"@target-uri\" http://example.com/foo?var1=&var2=2\n;created=1644758607;keyid=\"public.key\";alg=\"ed25519\";";
+    ParseResult parsed = new ParseResult(request);
+    assertEquals(expectedSeed, parsed.getSeed());
+  }
+
+  @Test
+  public void testExtraSpaces() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Date", "     Tue,     20     Apr      2021 02:07:55  GMT           ");
+    request.setHeader("Signature-Input", "\"date\";created=1644758607;keyid=\"public.key\";alg=\"ed25519\";");
+    String expectedSeed = "\"date\" Tue, 20 Apr 2021 02:07:55 GMT\n;created=1644758607;keyid=\"public.key\";alg=\"ed25519\";";
+    ParseResult parsed = new ParseResult(request);
+    assertEquals(expectedSeed, parsed.getSeed());
+  }
+
+  @Test
+  public void testMethodField() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input", "\"@method\";");
+    String expectedSeed = "\"@method\" POST\n;";
+    ParseResult parsed = new ParseResult(request);
+    assertEquals(expectedSeed, parsed.getSeed());
+  }
+
+  @Test
+  public void testAuthorityField() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input", "\"@authority\";");
+    String expectedSeed = "\"@authority\" example.com\n;";
+    ParseResult parsed = new ParseResult(request);
+    assertEquals(expectedSeed, parsed.getSeed());
+  }
+
+  @Test
+  public void testSchemeField() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input", "\"@scheme\";");
+    String expectedSeed = "\"@scheme\" http\n;";
+    ParseResult parsed = new ParseResult(request);
+    assertEquals(expectedSeed, parsed.getSeed());
+  }
+
+  @Test
+  public void testTargetURIField() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input", "\"@target-uri\";");
+    String expectedSeed = "\"@target-uri\" http://example.com/foo?var1=&var2=2\n;";
+    ParseResult parsed = new ParseResult(request);
+    assertEquals(expectedSeed, parsed.getSeed());
+  }
+
+  @Test
+  public void testPathField() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input", "\"@path\";");
+    String expectedSeed = "\"@path\" /foo\n;";
+    ParseResult parsed = new ParseResult(request);
+    assertEquals(expectedSeed, parsed.getSeed());
+  }
+
+  @Test
+  public void testQueryField() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input", "\"@query\";");
+    String expectedSeed = "\"@query\" ?var1=&var2=2\n;";
+    ParseResult parsed = new ParseResult(request);
+    assertEquals(expectedSeed, parsed.getSeed());
+  }
+
+  @Test
+  public void testQueryParamsField() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input", "\"@query-params\";");
+    String expectedSeed = "\"@query-params\";name=\"var1\": \n\"@query-params\";name=\"var2\": 2\n;";
+    ParseResult parsed = new ParseResult(request);
+    assertEquals(expectedSeed, parsed.getSeed());
+  }
+
+  @Test
+  public void testNonExistantSpecialityComponent() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input", "\"@x-test\";");
+    exceptionRule.expect(ParseResultException.class);
+    exceptionRule.expectMessage("Unhandled Derived Component @x-test");
+    new ParseResult(request);
+  }
+
+  @Test
+  public void testNonExistantHeaderField() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input", "\"x-test\";");
+    exceptionRule.expect(ParseResultException.class);
+    exceptionRule.expectMessage("Header field not found x-test");
+    new ParseResult(request);
+  }
+
+  @Test
+  public void testSignature() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input", "\"@query\";created=1644758607;keyid=\"public.key\";alg=\"ed25519\";");
+    ParseResult parsed = new ParseResult(request);
+    assertEquals("whatever", parsed.getSignature());
+  }
+
+  @Test
+  public void testKeyid() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input", "\"@query\";created=1644758607;keyid=\"public.key\";alg=\"ed25519\";");
+    ParseResult parsed = new ParseResult(request);
+    assertEquals("public.key", parsed.getKeyid());
+  }
+
+  @Test
+  public void testAlgorithm() throws URISyntaxException, ParseResultException {
+    HttpPost request = getRequest();
+    request.setHeader("Signature-Input", "\"@query\";created=1644758607;keyid=\"public.key\";alg=\"ed25519\";");
+    ParseResult parsed = new ParseResult(request);
+    assertEquals("ed25519", parsed.getAlgorithm());
+  }
+}


### PR DESCRIPTION
… via HTTP Header

* Add `org.apache.httpcomponents` dependency
* Add RequestSpecialityComponent to contain speciality component constants
* Add ParseResult that contains parser implementation
* Add ParseResultTest
* Add ParseResultException

Fix: #94

Signed-off-by: Omar Radwan <omarradwanx@gmail.com>