### PR TITLE
Add Support for Signature Validation via HTTP Header

### DIFF
--- a/src/main/java/com/alvarium/Sdk.java
+++ b/src/main/java/com/alvarium/Sdk.java
@@ -27,6 +27,7 @@ public interface Sdk {
    * custom values to them. The built-in annotators that require custom values are
    * <ul>
    * <li>TLS: Takes a key-value pair of "TLS": Socket</li>
+   * <li>PKIHttp: Takes a key-value pair of "PKIHttp": Http Request</li>
    * </ul>
    * @param data : data being annotated
    * @throws AnnotatorException

--- a/src/main/java/com/alvarium/annotators/AbstractPkiAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/AbstractPkiAnnotator.java
@@ -1,0 +1,54 @@
+package com.alvarium.annotators;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import com.alvarium.sign.KeyInfo;
+import com.alvarium.sign.SignException;
+import com.alvarium.sign.SignProvider;
+import com.alvarium.sign.SignProviderFactory;
+import com.alvarium.utils.Encoder;
+
+abstract class AbstractPkiAnnotator extends AbstractAnnotator {
+  /**
+   * Responsible for verifying the signature, returns true if the verification
+   * passed, false otherwise.
+   * 
+   * @param key      The public key used to verify the signature
+   * @param signable Contains the data (seed) and signature
+   * @return True if signature valid, false otherwise
+   * @throws AnnotatorException
+   */
+  protected Boolean verifySignature(KeyInfo key, Signable signable) throws AnnotatorException {
+    final SignProviderFactory signFactory = new SignProviderFactory();
+    final SignProvider signProvider;
+    try {
+      signProvider = signFactory.getProvider(key.getType());
+    } catch (SignException e) {
+      throw new AnnotatorException("Could not instantiate signing provider", e);
+    }
+
+    try {
+      // Load public key
+      final String publicKeyPath = key.getPath();
+      final String publicKey = Files.readString(
+          Paths.get(publicKeyPath),
+          StandardCharsets.US_ASCII);
+
+      // Verify signature
+      signProvider.verify(
+          Encoder.hexToBytes(publicKey),
+          signable.getSeed().getBytes(),
+          Encoder.hexToBytes(signable.getSignature()));
+
+      return true;
+    } catch (SignException e) {
+      return false;
+    } catch (IOException e) {
+      throw new AnnotatorException("Failed to load public key", e);
+    }
+
+  } 
+}

--- a/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
@@ -31,6 +31,8 @@ public class AnnotatorFactory {
         return new TlsAnnotator(hash, signature);
       case PKI:
         return new PkiAnnotator(hash, signature);
+      case PKIHttp:
+        return new PkiHttpAnnotator(hash, signature);
       case TPM:
         return new TpmAnnotator(hash, signature);
       case SOURCE:

--- a/src/main/java/com/alvarium/annotators/PkiAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/PkiAnnotator.java
@@ -14,26 +14,17 @@
  *******************************************************************************/
 package com.alvarium.annotators;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.Instant;
 
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
-import com.alvarium.sign.KeyInfo;
-import com.alvarium.sign.SignException;
-import com.alvarium.sign.SignProvider;
-import com.alvarium.sign.SignProviderFactory;
 import com.alvarium.sign.SignatureInfo;
-import com.alvarium.utils.Encoder;
 import com.alvarium.utils.PropertyBag;
 
-class PkiAnnotator extends AbstractAnnotator implements Annotator {
+class PkiAnnotator extends AbstractPkiAnnotator implements Annotator {
   private final HashType hash;
   private final SignatureInfo signature;
   private final AnnotationType kind;
@@ -73,44 +64,4 @@ class PkiAnnotator extends AbstractAnnotator implements Annotator {
 
   }
   
-  /**
-   * Responsible for verifying the signature, returns true if the verification passed, false 
-   * otherwise.
-   * 
-   * 
-   * @param key The public key used to verify the signature
-   * @param signable Contains the data (seed) and signature
-   * @return True if signature valid, false otherwise
-   * @throws AnnotatorException
-   */
-  private Boolean verifySignature(KeyInfo key, Signable signable) throws AnnotatorException {
-    final SignProviderFactory signFactory = new SignProviderFactory();
-    final SignProvider signProvider;
-    try {
-      signProvider = signFactory.getProvider(key.getType());
-    } catch(SignException e) {
-      throw new AnnotatorException("Could not instantiate signing provider", e);
-    }
-
-    try {
-      // Load public key
-      final String publicKeyPath = key.getPath();
-      final String publicKey = Files.readString(
-          Paths.get(publicKeyPath), 
-          StandardCharsets.US_ASCII);
-
-      // Verify signature
-      signProvider.verify(
-          Encoder.hexToBytes(publicKey), 
-          signable.getSeed().getBytes(), 
-          Encoder.hexToBytes(signable.getSignature()));
-
-      return true;
-    } catch(SignException e) {
-        return false;     
-    } catch(IOException e) {
-      throw new AnnotatorException("Failed to load public key", e);
-    }
-
-  }
 }

--- a/src/main/java/com/alvarium/annotators/PkiHttpAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/PkiHttpAnnotator.java
@@ -1,0 +1,104 @@
+
+/*******************************************************************************
+ * Copyright 2022 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.alvarium.annotators;
+
+import java.net.InetAddress;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.nio.file.Path;
+
+import com.alvarium.annotators.http.ParseResult;
+import com.alvarium.annotators.http.ParseResultException;
+import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashType;
+import com.alvarium.sign.KeyInfo;
+import com.alvarium.sign.SignatureInfo;
+import com.alvarium.sign.SignType;
+import com.alvarium.utils.PropertyBag;
+
+import org.apache.http.client.methods.HttpUriRequest;
+
+class PkiHttpAnnotator extends AbstractPkiAnnotator implements Annotator {
+  private final HashType hash;
+  private final SignatureInfo signature;
+  private final AnnotationType kind;
+
+  protected PkiHttpAnnotator(HashType hash, SignatureInfo signature) {
+    this.hash = hash;
+    this.signature = signature;
+    this.kind = AnnotationType.PKIHttp;
+  }
+
+  public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
+    final String key = super.deriveHash(hash, data);
+
+    String host;
+    try {
+      host = InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      throw new AnnotatorException("Cannot get host name", e);
+    }
+
+    HttpUriRequest request;
+    try {
+      request = ctx.getProperty(AnnotationType.PKIHttp.name(), HttpUriRequest.class);
+    } catch (IllegalArgumentException e) {
+      throw new AnnotatorException(String.format("Property %s not found", AnnotationType.PKIHttp.name()));
+    }
+    ParseResult parsed; 
+    try {
+      parsed = new ParseResult(request);
+    } catch (URISyntaxException e) {
+      throw new AnnotatorException("Invalid request URI", e);
+    } catch (ParseResultException e) {
+      throw new AnnotatorException("Error parsing the request", e);
+    }
+    final Signable signable = new Signable(parsed.getSeed(), parsed.getSignature());
+
+    // Use the parsed request to obtain the key name and type we should use to
+    // validate the signature
+    Path path = Paths.get(signature.getPublicKey().getPath());
+    Path directory = path.getParent();
+    String publicKeyPath = String.join("/", directory.toString(), parsed.getKeyid());
+
+    SignType alg;
+    try {
+      alg = SignType.fromString(parsed.getAlgorithm());
+    } catch (EnumConstantNotPresentException e) {
+      throw new AnnotatorException("Invalid key type " + parsed.getAlgorithm());
+    }
+    KeyInfo publicKey = new KeyInfo(publicKeyPath, alg);
+    SignatureInfo sig = new SignatureInfo(publicKey, signature.getPrivateKey());
+
+    Boolean isSatisfied = verifySignature(sig.getPublicKey(), signable);
+
+    final Annotation annotation = new Annotation(
+        key,
+        hash,
+        host,
+        kind,
+        null,
+        isSatisfied,
+        Instant.now());
+
+    final String annotationSignature = super.signAnnotation(sig.getPrivateKey(), annotation);
+    annotation.setSignature(annotationSignature);
+    return annotation;
+  }
+}

--- a/src/main/java/com/alvarium/contracts/AnnotationType.java
+++ b/src/main/java/com/alvarium/contracts/AnnotationType.java
@@ -25,6 +25,8 @@ public enum AnnotationType {
   TLS,
   @SerializedName(value = "pki")
   PKI,
+  @SerializedName(value = "pki-http")
+  PKIHttp,
   @SerializedName(value = "src")
   SOURCE;
 }

--- a/src/test/java/com/alvarium/annotators/PkiHttpAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/PkiHttpAnnotatorTest.java
@@ -1,0 +1,195 @@
+
+/*******************************************************************************
+ * Copyright 2022 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.alvarium.annotators;
+
+import java.util.HashMap;
+import java.util.Date;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+
+import com.alvarium.SdkInfo;
+import com.alvarium.annotators.http.Ed2551RequestHandler;
+import com.alvarium.annotators.http.RequestHandlerException;
+import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.DerivedComponent;
+import com.alvarium.hash.HashInfo;
+import com.alvarium.hash.HashType;
+import com.alvarium.sign.KeyInfo;
+import com.alvarium.sign.SignType;
+import com.alvarium.sign.SignatureInfo;
+import com.alvarium.utils.ImmutablePropertyBag;
+import com.alvarium.utils.PropertyBag;
+
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PkiHttpAnnotatorTest {
+  final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
+  final KeyInfo pubKey = new KeyInfo("./src/test/java/com/alvarium/annotators/public.key",
+      SignType.Ed25519);
+  final KeyInfo privKey = new KeyInfo("./src/test/java/com/alvarium/annotators/private.key",
+      SignType.Ed25519);
+  final SignatureInfo sigInfo = new SignatureInfo(pubKey, privKey);
+  final byte[] data = String.format("{key: \"test\"}").getBytes();
+
+  HttpPost getRequest(SignatureInfo sigInfo) throws RequestHandlerException {
+    HttpPost request = new HttpPost(URI.create("http://example.com/foo?var1=&var2=2"));
+    Date date = new Date();
+    request.setHeader("Date", date.toString());
+    request.setHeader("Content-Type", "application/json");
+    request.setHeader("Content-Length", "18");
+    String[] fields = { DerivedComponent.METHOD.getValue(),
+        DerivedComponent.PATH.getValue(),
+        DerivedComponent.AUTHORITY.getValue(),
+        "Content-Type", "Content-Length" };
+    Ed2551RequestHandler requestHandler = new Ed2551RequestHandler(request);
+    requestHandler.addSignatureHeaders(date, fields, sigInfo);
+    return request;
+  }
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Test
+  // Tests the Signature signed by the assembler
+  public void testAnnotationOK() throws AnnotatorException, RequestHandlerException {
+    HttpPost request = getRequest(sigInfo);
+    try {
+      request.setEntity(new StringEntity("{key: \"test\"}"));
+    } catch (UnsupportedEncodingException e) {
+      throw new AnnotatorException("Unsupported Character Encoding", e);
+    }
+
+    HashMap<String, Object> map = new HashMap<>();
+    map.put(AnnotationType.PKIHttp.name(), request);
+    final PropertyBag ctx = new ImmutablePropertyBag(map);
+
+    final AnnotationType[] annotators = { AnnotationType.PKIHttp };
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKIHttp, config);
+    final Annotation annotation = annotator.execute(ctx, data);
+    assertTrue("isSatisfied should be true", annotation.getIsSatisfied());
+  }
+
+  @Test
+  public void testInvalidKeyType() throws AnnotatorException, RequestHandlerException {
+    final String signatureInput = "\"@method\" \"@path\" \"@authority\" \"Content-Type\" " + 
+    "\"Content-Length\";created=1646146637;keyid=\"public.key\";alg=\"invalid\"";
+
+    HttpPost request = getRequest(sigInfo);
+    try {
+      request.setEntity(new StringEntity("{key: \"test\"}"));
+    } catch (UnsupportedEncodingException e) {
+      throw new AnnotatorException("Unsupported Character Encoding", e);
+
+    }
+    request.setHeader("Signature-Input", signatureInput);
+
+    HashMap<String, Object> map = new HashMap<>();
+    map.put(AnnotationType.PKIHttp.name(), request);
+    final PropertyBag ctx = new ImmutablePropertyBag(map);
+
+    exceptionRule.expect(AnnotatorException.class);
+    exceptionRule.expectMessage("Invalid key type invalid");
+
+    final AnnotationType[] annotators = { AnnotationType.PKIHttp };
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKIHttp, config);
+    annotator.execute(ctx, data);
+  }
+
+  @Test
+  public void testKeyNotFound() throws AnnotatorException, RequestHandlerException {
+    final String signatureInput = "\"@method\" \"@path\" \"@authority\" \"Content-Type\" " + 
+    "\"Content-Length\";created=1646146637;keyid=\"invalid\";alg=\"ed25519\"";
+
+    HttpPost request = getRequest(sigInfo);
+    try {
+      request.setEntity(new StringEntity("{key: \"test\"}"));
+    } catch (UnsupportedEncodingException e) {
+      throw new AnnotatorException("Unsupported Character Encoding", e);
+
+    }
+    request.setHeader("Signature-Input", signatureInput);
+
+    HashMap<String, Object> map = new HashMap<>();
+    map.put(AnnotationType.PKIHttp.name(), request);
+    final PropertyBag ctx = new ImmutablePropertyBag(map);
+
+    exceptionRule.expect(AnnotatorException.class);
+    exceptionRule.expectMessage("Failed to load public key");
+
+    final AnnotationType[] annotators = { AnnotationType.PKIHttp };
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKIHttp, config);
+    annotator.execute(ctx, data);
+  }
+
+  @Test
+  public void testEmptySignature() throws AnnotatorException, RequestHandlerException {
+    final String signature = "";
+
+    HttpPost request = getRequest(sigInfo);
+    try {
+      request.setEntity(new StringEntity("{key: \"test\"}"));
+    } catch (UnsupportedEncodingException e) {
+      throw new AnnotatorException("Unsupported Character Encoding", e);
+
+    }
+    request.setHeader("Signature", signature);
+
+    HashMap<String, Object> map = new HashMap<>();
+    map.put(AnnotationType.PKIHttp.name(), request);
+    final PropertyBag ctx = new ImmutablePropertyBag(map);
+
+    final AnnotationType[] annotators = { AnnotationType.PKIHttp };
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKIHttp, config);
+    final Annotation annotation = annotator.execute(ctx, data);
+    assertFalse("isSatisfied should be false", annotation.getIsSatisfied());
+  }
+
+  @Test
+  public void testInvalidSignature() throws AnnotatorException, RequestHandlerException {
+    final String signature = "invalid";
+
+    HttpPost request = getRequest(sigInfo);
+    try {
+      request.setEntity(new StringEntity("{key: \"test\"}"));
+    } catch (UnsupportedEncodingException e) {
+      throw new AnnotatorException("Unsupported Character Encoding", e);
+
+    }
+    request.setHeader("Signature", signature);
+
+    HashMap<String, Object> map = new HashMap<>();
+    map.put(AnnotationType.PKIHttp.name(), request);
+    final PropertyBag ctx = new ImmutablePropertyBag(map);
+
+    final AnnotationType[] annotators = { AnnotationType.PKIHttp };
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKIHttp, config);
+    final Annotation annotation = annotator.execute(ctx, data);
+    assertFalse("isSatisfied should be false", annotation.getIsSatisfied());
+  }
+}


### PR DESCRIPTION
* Add AbstractPkiAnnotator
* Add PkiHttpAnnotator
* Add PkiHttp to AnnotatorFactory
* Add PkiHttp to AnnotationType
* Add PkiHttpAnnotator tests

 Fix #93

Signed-off-by: Mohanad <mohanadismail789@gmail.com>