### PR TITLE
Add SourceCodeAnnotator implementation and relevant tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,28 @@
+pipeline {
+    agent any
+    tools {
+        maven 'M3'
+    }
+    stages {
+        stage ('test') {
+            steps {
+                sh 'mvn test'
+            }
+            post {
+                success {
+                    junit 'target/surefire-reports/**/*.xml'
+                }
+            }
+        }
+        stage ('build') {
+            steps {
+                sh 'mvn package'
+            }
+            post {
+                success {
+                    archiveArtifacts artifacts: 'target/**/*.jar', fingerprint: true
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
@@ -35,10 +35,12 @@ public class AnnotatorFactory {
         return new PkiHttpAnnotator(hash, signature);
       case TPM:
         return new TpmAnnotator(hash, signature);
+      case SourceCode:
+        return new SourceCodeAnnotator(hash, signature);
       case SOURCE:
         return new SourceAnnotator(hash, signature);
       default:
-        throw new AnnotatorException("Annotator type is not supported"); 
+        throw new AnnotatorException("Annotator type is not supported");
     }
-  }  
+  }
 }

--- a/src/main/java/com/alvarium/annotators/SourceCodeAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/SourceCodeAnnotator.java
@@ -1,0 +1,203 @@
+
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.alvarium.annotators;
+
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashProvider;
+import com.alvarium.hash.HashProviderFactory;
+import com.alvarium.hash.HashType;
+import com.alvarium.hash.HashTypeException;
+import com.alvarium.sign.SignatureInfo;
+import com.alvarium.utils.PropertyBag;
+
+class SourceCodeAnnotator extends AbstractAnnotator implements Annotator {
+
+    private final HashType hash;
+    private final AnnotationType kind;
+    private final SignatureInfo signature;
+
+    private HashProvider hashProvider;
+
+    protected SourceCodeAnnotator(HashType hash, SignatureInfo signature) {
+        this.hash = hash;
+        this.kind = AnnotationType.SourceCode;
+        this.signature = signature;
+    }
+
+    // File (git working directory) is to be passed in the ctx bag
+    // expects commitHash and directory from ctx
+    @Override
+    public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
+        this.initHashProvider(this.hash);
+        final String key = this.hashProvider.derive(data);
+        String host;
+        try {
+            host = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            throw new AnnotatorException("Cannot get host name.", e);
+        }
+
+        final SourceCodeAnnotatorProps props = ctx.getProperty(
+            AnnotationType.SourceCode.name(),
+            SourceCodeAnnotatorProps.class
+        );
+        
+        final String checksum = this.readChecksum(props.getChecksumPath());
+        final String generatedChecksum = this.generateChecksum(props.getSourceCodePath());
+
+        final Boolean isSatisfied = generatedChecksum.equals(checksum);
+
+        final Annotation annotation = new Annotation(
+                key,
+                hash,
+                host,
+                kind,
+                null,
+                isSatisfied,
+                Instant.now());
+
+        final String annotationSignature = super.signAnnotation(signature.getPrivateKey(), annotation);
+        annotation.setSignature(annotationSignature);
+        return annotation;
+    }
+
+    private String generateChecksum(String sourceCodePath) throws AnnotatorException {
+        final Optional<AnnotatorException> exc = this.findFiles(sourceCodePath)
+            .sorted()  // ensures hash is detirministic
+            .flatMap(this::readAndHashFile) 
+            .reduce(this::exceptionReducer);
+
+            if(exc.isPresent()) {
+                final AnnotatorException exception = exc.get();
+                throw exception;
+            }
+
+            final String hashValue = this.hashProvider.getValue();
+            return hashValue;
+        
+    }
+
+    private String readChecksum(String path) throws AnnotatorException {
+        try {
+            final Path p = Paths.get(path);
+            return Files.readString(p);
+        } catch (IOException e) {
+            throw new AnnotatorException("Failed to read file, could not validate checksum", e);
+        } catch (SecurityException e) {
+            throw new AnnotatorException(
+                "Insufficient permission to access file, could not validate checksum", 
+                e
+            );
+        } catch (OutOfMemoryError e) {
+            throw new AnnotatorException(
+                "Failed to read file due to size larger than 2GB, could not validate checksum " + e
+            );
+        } catch (Exception e) {
+            throw new AnnotatorException("Could not validate checksum");
+        }
+    }
+
+    /**
+     *  Initializes the hash provider used to hash the source code 
+     * @return HashProvider
+     * @throws AnnotatorException - If hashing algorithm not found, 
+     * or if an unknown exception was thrown
+     */
+    private final void initHashProvider(HashType hashType) throws AnnotatorException {
+        try {
+             this.hashProvider = new HashProviderFactory().getProvider(hashType);
+        } catch (HashTypeException e) {
+            throw new AnnotatorException("Hashing algorithm not found, could not hash data or generate checksum", e);
+        } catch (Exception e) {
+            throw new AnnotatorException("Could not hash data or generate checksum", e);
+        }
+    }
+
+    /**
+     * @return Stream of file paths found
+     * @throws AnnotatorException - When bad or non-existant Path is provided
+     */
+    private Stream<Path> findFiles(String directory) throws AnnotatorException {
+        try {
+            return Files.find(
+                Paths.get(directory), 
+                Integer.MAX_VALUE, 
+                (Path filePath, BasicFileAttributes fileAttr) -> !fileAttr.isDirectory() // read all files
+            );
+        } catch (IOException e) {
+            throw new AnnotatorException("Failed to read files, could not generate checksum", e);
+        } catch (Exception e) {
+            throw new AnnotatorException("Could not generate checksum", e);
+        }
+    }
+
+    /**
+     * Attempts to read file and update the MD5 hash with it.
+     * 
+     * @param file - path to file 
+     * @return Stream - steam of an exception if any were thrown, if none then returns null
+     *  
+     */
+    private Stream<AnnotatorException> readAndHashFile(Path file) {
+        AnnotatorException excWrapper;
+        try {
+            this.hashProvider.update(Files.readAllBytes(file));
+            return null;
+        } catch (OutOfMemoryError e) {
+            excWrapper = new AnnotatorException(
+                "Failed to read file due to size larger than 2GB, could not validate checksum" + e
+            );
+        } catch (IOException e) {
+            excWrapper = new AnnotatorException(
+                "Failed to read file contents, could not generate checksum", 
+                e
+            );
+        } catch (SecurityException e) {
+            excWrapper = new AnnotatorException(
+                "Insufficient permission to access file, could not validate checksum",
+                e
+            );
+        } catch (Exception e) {
+            excWrapper = new AnnotatorException("Could not validate checksum", e);
+        }
+        return Stream.of(excWrapper);
+    }
+
+    /**
+     * Suppresses all exceptions in favor of the first exception thrown
+     * @param accumulator
+     * @param exc
+     * @return Exception - first exception thrown 
+     */
+    private AnnotatorException exceptionReducer(AnnotatorException accumulator, AnnotatorException exc) {
+        accumulator.addSuppressed(exc);
+        return accumulator;
+    }
+
+
+}

--- a/src/main/java/com/alvarium/annotators/SourceCodeAnnotatorProps.java
+++ b/src/main/java/com/alvarium/annotators/SourceCodeAnnotatorProps.java
@@ -1,0 +1,20 @@
+package com.alvarium.annotators;
+
+
+public class SourceCodeAnnotatorProps {
+    final private String sourceCodePath;
+    final private String checksumPath;
+
+    public SourceCodeAnnotatorProps(String sourceCodePath, String checksumPath) {
+        this.checksumPath = checksumPath;
+        this.sourceCodePath = sourceCodePath;
+    }
+
+    final public String getSourceCodePath() {
+        return this.sourceCodePath;
+    }
+    
+    final public String getChecksumPath() {
+        return this.checksumPath;
+    }
+}

--- a/src/main/java/com/alvarium/contracts/AnnotationType.java
+++ b/src/main/java/com/alvarium/contracts/AnnotationType.java
@@ -18,7 +18,7 @@ import com.google.gson.annotations.SerializedName;
 
 public enum AnnotationType {
   @SerializedName(value = "tpm")
-  TPM, 
+  TPM,
   @SerializedName(value = "mock")
   MOCK,
   @SerializedName(value = "tls")
@@ -27,6 +27,8 @@ public enum AnnotationType {
   PKI,
   @SerializedName(value = "pki-http")
   PKIHttp,
+  @SerializedName(value = "source-code")
+  SourceCode,
   @SerializedName(value = "src")
   SOURCE;
 }

--- a/src/main/java/com/alvarium/hash/HashProvider.java
+++ b/src/main/java/com/alvarium/hash/HashProvider.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -25,4 +25,18 @@ public interface HashProvider {
    * @return hashed value of the given data
    */
   String derive(byte[] data);
+
+  /**
+   * Updates the hash with new input data
+   * @param data byte array of data
+   * @return new hashed value of the given data
+   */
+  void update(byte[] data);
+
+  /**
+   * Gets the current hash, resets any saved values from previous <code>update()</code>
+   * calls
+   * @return the final hashing result of previous <code>update()</code> calls 
+   */
+  String getValue();
 }

--- a/src/main/java/com/alvarium/hash/Md5Provider.java
+++ b/src/main/java/com/alvarium/hash/Md5Provider.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,20 @@ class Md5Provider implements HashProvider{
     }
   }
 
+  @Override
   public String derive(byte[] data) {
-    final byte[] hashedBytes = md5.digest(data);
-    final String hashedString = Encoder.bytesToHex(hashedBytes);
+    final byte[] hashedBytes = this.md5.digest(data);
+    return Encoder.bytesToHex(hashedBytes);
+  }
+
+  @Override
+  public void update(byte[] data) {
+    this.md5.update(data);
+  }
+
+  @Override
+  public String getValue() {
+    final String hashedString = Encoder.bytesToHex(this.md5.digest());
     return hashedString;
   }
 }

--- a/src/main/java/com/alvarium/hash/NoneProvider.java
+++ b/src/main/java/com/alvarium/hash/NoneProvider.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,8 +15,21 @@
 package com.alvarium.hash;
 
 class NoneProvider implements HashProvider {
+  private byte[] hashValue;
+
   @Override
   public String derive(byte[] data) {
+    this.hashValue = data;
     return new String(data);
+  }
+
+  @Override
+  public void update(byte[] data) {
+    this.hashValue = data;
+  }
+
+  @Override
+  public String getValue() {
+    return new String(this.hashValue);
   }
 }

--- a/src/main/java/com/alvarium/hash/Sha256Provider.java
+++ b/src/main/java/com/alvarium/hash/Sha256Provider.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -32,9 +32,21 @@ class Sha256Provider implements HashProvider {
   }
 
   // returns the hexadecimal sha256 hash representation of the given data
+  @Override
   public String derive(byte[] data) {
     final byte[] hashedBytes = this.sha256.digest(data);
     final String hashedString = Encoder.bytesToHex(hashedBytes);
     return hashedString; 
+  }
+
+  @Override
+  public void update(byte[] data) {
+    this.sha256.update(data);
+  }
+
+  @Override
+  public String getValue() {
+    final String hashedString = Encoder.bytesToHex(this.sha256.digest());
+    return hashedString;
   }
 }

--- a/src/test/java/com/alvarium/annotators/SourceCodeAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/SourceCodeAnnotatorTest.java
@@ -1,0 +1,148 @@
+
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.alvarium.annotators;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+
+
+import com.alvarium.SdkInfo;
+import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashInfo;
+import com.alvarium.hash.HashProvider;
+import com.alvarium.hash.HashProviderFactory;
+import com.alvarium.hash.HashType;
+import com.alvarium.sign.KeyInfo;
+import com.alvarium.sign.SignType;
+import com.alvarium.sign.SignatureInfo;
+import com.alvarium.utils.ImmutablePropertyBag;
+import com.alvarium.utils.PropertyBag;
+
+public class SourceCodeAnnotatorTest {
+
+        @Rule
+        public TemporaryFolder dir = new TemporaryFolder();
+
+        @Test
+        public void executeShouldReturnAnnotation() throws AnnotatorException {
+                AnnotatorFactory factory = new AnnotatorFactory();
+                KeyInfo privateKey = new KeyInfo(
+                                "./src/test/java/com/alvarium/annotators/public.key",
+                                SignType.Ed25519);
+                KeyInfo publicKey = new KeyInfo(
+                                "./src/test/java/com/alvarium/annotators/public.key",
+                                SignType.Ed25519);
+
+                SignatureInfo sign = new SignatureInfo(publicKey, privateKey);
+                final AnnotationType[] annotators = { AnnotationType.SourceCode };
+                final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
+                Annotator annotator = factory.getAnnotator(AnnotationType.SourceCode, config);
+
+                // Generate dummy source code directory and 
+                // generate checksum for dummy source code
+                File sourceCodeDir;
+                File checksum; 
+                File f1;
+                try {
+                        sourceCodeDir = dir.newFolder("source-code");
+                        f1 = new File(sourceCodeDir.toPath().toString() + "/f1");
+                        checksum = dir.newFile("checksum");
+                } catch (IOException e) {
+                        throw new AnnotatorException("Could not create test file", e);
+                }
+                
+                generateAndWriteChecksum(sourceCodeDir, checksum.toPath(), config.getHash().getType());
+
+                final SourceCodeAnnotatorProps props = 
+                        new SourceCodeAnnotatorProps(
+                                sourceCodeDir.toPath().toString(), 
+                                checksum.toPath().toString()
+                );
+
+                PropertyBag ctx = new ImmutablePropertyBag(
+                        Map.of(AnnotationType.SourceCode.name(), props)
+                );
+
+                byte[] data = "pipeline1/1".getBytes();
+
+                Annotation annotation = annotator.execute(ctx, data);
+                System.out.println(annotation.toJson());
+                assert annotation.getIsSatisfied();
+
+                // tamper with existing file in source code
+                try {
+                        Files.write(f1.toPath(), "foo".getBytes()); 
+                } catch (IOException e) {
+                        throw new AnnotatorException("Could not write to test file", e);
+                }
+                
+                annotation = annotator.execute(ctx, data);
+                System.out.println(annotation.toJson());
+
+                assert !annotation.getIsSatisfied();
+
+        }
+
+
+        /**
+         * Writes the checksum of a sourceCodeDir to a file located at checksumPath using the same
+         * hashing algorithm provided to the source annotator
+         * @param sourceCodeDir
+         * @param checksumPath
+         * @throws AnnotatorException
+         */
+        private void generateAndWriteChecksum(File sourceCodeDir, Path checksumPath, HashType hashType) throws AnnotatorException {
+                try {
+                        final HashProvider hash = new HashProviderFactory().getProvider(hashType);
+                        Optional<Exception> exception = Files.find(
+                                Paths.get(sourceCodeDir.toURI()), 
+                                Integer.MAX_VALUE, 
+                                (Path filePath, BasicFileAttributes fileAttr) -> !fileAttr.isDirectory()) 
+                                .sorted() 
+                                .flatMap((Path f) ->  {
+                                        try {
+                                                hash.update(Files.readAllBytes(f));
+                                                return null;
+                                        } catch (Exception e) {
+                                                return Stream.of(e);
+                                        }
+                                })
+                                .reduce((Exception exc1, Exception exc2) -> {
+                                        exc1.addSuppressed(exc2);
+                                        return exc1;
+                                });
+                        if (exception.isPresent()) {
+                                throw new AnnotatorException("Error reading files", exception.get());
+                        }
+                        Files.write(checksumPath, hash.getValue().getBytes());
+                } catch (Exception e) {
+                        throw new AnnotatorException("foo", e);
+                }
+        }
+
+}

--- a/src/test/java/com/alvarium/hash/HashProviderTest.java
+++ b/src/test/java/com/alvarium/hash/HashProviderTest.java
@@ -1,4 +1,4 @@
-
+// 
 /*******************************************************************************
  * Copyright 2021 Dell Inc.
  *
@@ -59,6 +59,32 @@ public class HashProviderTest {
       final String result = sut.derive(testCases[i].getBytes()); 
       assertEquals(md5Hashes[i], result);
     }
+  }
+
+  @Test
+  public void md5ProviderUpdateReturnsSameAsDerive() throws Exception {
+    HashProviderFactory hashProviderFactory = new HashProviderFactory();
+    HashProvider provider = hashProviderFactory.getProvider(HashType.MD5Hash);
+    
+    final String exampleString = "foo";
+    provider.update(exampleString.getBytes());
+    String hash1 = provider.getValue();
+    String hash2 = provider.derive(exampleString.getBytes());
+
+    assert hash1.equals(hash2);
+  }
+
+  @Test
+  public void sha256ProviderUpdateReturnsSameAsDerive() throws Exception {
+    HashProviderFactory hashProviderFactory = new HashProviderFactory();
+    HashProvider provider = hashProviderFactory.getProvider(HashType.SHA256Hash);
+
+    final String exampleString = "foo";
+    provider.update(exampleString.getBytes());
+    String hash1 = provider.getValue();
+    String hash2 = provider.derive(exampleString.getBytes());
+
+    assert hash1.equals(hash2);
   }
 
   String generateRandomString(int length) {


### PR DESCRIPTION
* Implement a `SourceCodeUtil` class that abstracts reading directory
  files and hashing them
* Add `update()` and `getValue()` methods to the hash provider to
  enable hashing by parts. This was used to hash each file in the
  source code util without loading all files into a buffer
* Implement the `SourceCodeAnnotator` which replaced the proposed
  git annotator. This annotator takes a path to a checksum and a
  path to the source code directory and does the required verification
  to match the source code with the provided checksum.
* Implemented relevant unit tests
* Add missing `@Override` decorators to `HashProvider` implementations
* Add `SourceCodeAnnotatorProps` class to facilitate passing
  multi-valued ctx to annotator

Signed-off-by: Ali Amin <ali.m.amin98@gmail.com>

- The changes in this PR should replace the need for the `GitAnnotator` proposed in #99.
- I tested this PR on a codebase with a generated checksum and it produced a "satisfied" annotation. This was on a linux system but it still needs testing on other platforms, I'll post updates when I reach something.

Edit 6/5/2023:
- The generated checksum matches even when using different platforms. Tested it on windows and the same checksum was produced when tested on Ubuntu.