### PR TITLE
Add ChecksumAnnotator and relevant tests

### DIFF
--- a/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -37,6 +36,8 @@ public class AnnotatorFactory {
         return new TpmAnnotator(hash, signature);
       case SourceCode:
         return new SourceCodeAnnotator(hash, signature);
+      case CHECKSUM:
+        return new ChecksumAnnotator(hash, signature);
       case SOURCE:
         return new SourceAnnotator(hash, signature);
       default:

--- a/src/main/java/com/alvarium/annotators/ChecksumAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/ChecksumAnnotator.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.alvarium.annotators;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Instant;
+
+import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashProvider;
+import com.alvarium.hash.HashProviderFactory;
+import com.alvarium.hash.HashType;
+import com.alvarium.hash.HashTypeException;
+import com.alvarium.sign.SignatureInfo;
+import com.alvarium.utils.PropertyBag;
+
+public class ChecksumAnnotator extends AbstractAnnotator implements Annotator {
+
+    final private HashType hash;
+    final private SignatureInfo signature;
+    private final AnnotationType kind;
+
+    private HashProvider hashProvider;
+
+    protected ChecksumAnnotator(HashType hash, SignatureInfo signature) {
+        this.hash = hash;
+        this.signature = signature;
+        this.kind = AnnotationType.CHECKSUM;
+    }
+    
+    @Override
+    public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
+        
+        this.initHashProvider(this.hash);
+        final String key = this.hashProvider.derive(data);
+
+        final String host;
+        try {
+            host = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            throw new AnnotatorException("Cannot get host name", e);
+        }
+
+        final ChecksumAnnotatorProps props = ctx.getProperty(
+            AnnotationType.CHECKSUM.name(), 
+            ChecksumAnnotatorProps.class
+        );
+
+        // Get artifact checksum
+        final String checksum = this.readFile(props.getChecksumPath());
+
+        // Validate artifact checksum
+        final String artifactHash = this.hashFile(props.getArtifactPath());
+
+        final boolean isSatisfied = checksum.equals(artifactHash);
+
+        final Annotation annotation = new Annotation(
+            key, 
+            this.hash, 
+            host, 
+            this.kind, 
+            null, 
+            isSatisfied, 
+            Instant.now()
+        );
+
+        final String annotationSignature = super.signAnnotation(
+            this.signature.getPrivateKey(), 
+            annotation
+        );
+        annotation.setSignature(annotationSignature);
+        return annotation;
+    }
+    
+    /**
+    *  Initializes a hash provider 
+    * @return HashProvider
+    * @throws AnnotatorException - If hashing algorithm not found, 
+    * or if an unknown exception was thrown
+    */
+    private final void initHashProvider(HashType hashType) throws AnnotatorException {
+        try {
+             this.hashProvider = new HashProviderFactory().getProvider(hashType);
+        } catch (HashTypeException e) {
+            throw new AnnotatorException("Hashing algorithm not found, could not hash data or validate checksum", e);
+        } catch (Exception e) {
+            throw new AnnotatorException("Could not hash data or validate checksum", e);
+        }
+    }
+
+    /**
+     * Reads a file on the local file system
+     * @param filePath
+     * @return String content of file
+     * @throws AnnotatorException - When bad file path or corrupted file given
+     */
+    private final String readFile(String filePath) throws AnnotatorException {
+        final String content;
+        try {
+          content = Files.readString(
+                Paths.get(filePath),
+                StandardCharsets.UTF_8
+            );
+        } catch (IOException e) {
+            throw new AnnotatorException("Failed to read file, could not validate checksum", e);
+        }
+        return content;
+    }
+
+   /**
+     * Reads and hashes a file on the local file system in in chunks of 8KB 
+     * @param filePath
+     * @return hash of the file's contents in string format
+     * @throws AnnotatorException - When bad file path or corrupted file given
+     */
+     private final String hashFile(String filePath) throws AnnotatorException {
+        try {
+            FileInputStream fs = new FileInputStream(filePath);
+            final byte[] buffer = new byte[8192];
+
+            int bytesRead = 0;
+            while (true) {
+                bytesRead = fs.read(buffer);
+                if (bytesRead == -1) { // indicates EOF
+                    break;
+                } else {
+                    this.hashProvider.update(buffer, 0, bytesRead);
+                }
+            }
+
+            fs.close();
+        } catch(IOException e) {
+            throw new AnnotatorException(
+                "Failed to hash artifact, could not validate checksum", 
+                e
+            );
+        }
+
+        return this.hashProvider.getValue();
+    }
+}

--- a/src/main/java/com/alvarium/annotators/ChecksumAnnotatorProps.java
+++ b/src/main/java/com/alvarium/annotators/ChecksumAnnotatorProps.java
@@ -11,30 +11,22 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
-package com.alvarium.hash;
+package com.alvarium.annotators;
 
-import java.util.Arrays;
+public class ArtifactAnnotatorProps {
+    final private String checksumPath;
+    final private String artifactPath;
+    
+    public ArtifactAnnotatorProps(String artifactPath, String checksumPath) {
+        this.artifactPath = artifactPath;
+        this.checksumPath = checksumPath;
+    }
 
-class NoneProvider implements HashProvider {
-  private byte[] hashValue;
+    public String getChecksumPath() {
+        return this.checksumPath;
+    }
 
-  @Override
-  public String derive(byte[] data) {
-    this.hashValue = data;
-    return new String(data);
-  }
-
-  @Override
-  public void update(byte[] data) {
-    this.hashValue = data;
-  }
-
-  public void update(byte[] data, int offset, int size) {
-    this.hashValue = Arrays.copyOfRange(data, offset, size);
-  }
-
-  @Override
-  public String getValue() {
-    return new String(this.hashValue);
-  }
+    public String getArtifactPath() {
+        return this.artifactPath;
+    }
 }

--- a/src/main/java/com/alvarium/contracts/AnnotationType.java
+++ b/src/main/java/com/alvarium/contracts/AnnotationType.java
@@ -1,6 +1,5 @@
-
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -29,6 +28,8 @@ public enum AnnotationType {
   PKIHttp,
   @SerializedName(value = "source-code")
   SourceCode,
+  @SerializedName(value = "checksum")
+  CHECKSUM,
   @SerializedName(value = "src")
   SOURCE;
 }

--- a/src/main/java/com/alvarium/hash/HashProvider.java
+++ b/src/main/java/com/alvarium/hash/HashProvider.java
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright 2023 Dell Inc.
  *
@@ -32,6 +31,17 @@ public interface HashProvider {
    * @return new hashed value of the given data
    */
   void update(byte[] data);
+  
+  /**
+   * Updates the hash with new input data. Useful when hashing large byte arrays in chunks 
+   * where the <code>offset</code> and <code>length</code> parameters can prevent alloting
+   * padded 0's to the digest when the input buffer is partially filled
+   * @param data byte array of data
+   * @param offset offset into the output buffer to begin storing the digest
+   * @param length number of bytes within buffer allotted for the digest
+   * @return new hashed value of the given data
+   */
+  public void update(byte[] buffer, int offset, int length);
 
   /**
    * Gets the current hash, resets any saved values from previous <code>update()</code>

--- a/src/main/java/com/alvarium/hash/Md5Provider.java
+++ b/src/main/java/com/alvarium/hash/Md5Provider.java
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright 2023 Dell Inc.
  *
@@ -39,6 +38,11 @@ class Md5Provider implements HashProvider{
   @Override
   public void update(byte[] data) {
     this.md5.update(data);
+  }
+
+  @Override
+  public void update(byte[] data, int offset, int size) {
+    this.md5.update(data, offset, size);
   }
 
   @Override

--- a/src/main/java/com/alvarium/hash/Sha256Provider.java
+++ b/src/main/java/com/alvarium/hash/Sha256Provider.java
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright 2023 Dell Inc.
  *
@@ -42,6 +41,11 @@ class Sha256Provider implements HashProvider {
   @Override
   public void update(byte[] data) {
     this.sha256.update(data);
+  }
+
+  @Override
+  public void update(byte[] data, int offset, int size) {
+    this.sha256.update(data, offset, size);
   }
 
   @Override

--- a/src/test/java/com/alvarium/annotators/ChecksumAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/ChecksumAnnotatorTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.alvarium.annotators;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.alvarium.SdkInfo;
+import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.hash.HashInfo;
+import com.alvarium.hash.HashProvider;
+import com.alvarium.hash.HashProviderFactory;
+import com.alvarium.hash.HashType;
+import com.alvarium.hash.HashTypeException;
+import com.alvarium.sign.KeyInfo;
+import com.alvarium.sign.SignType;
+import com.alvarium.sign.SignatureInfo;
+import com.alvarium.utils.ImmutablePropertyBag;
+import com.alvarium.utils.PropertyBag;
+
+public class ChecksumAnnotatorTest {
+    @Rule
+    public TemporaryFolder dir = new TemporaryFolder();
+
+    @Test
+    public void executeShouldReturnAnnotation() throws AnnotatorException, HashTypeException, IOException {
+
+            AnnotatorFactory factory = new AnnotatorFactory();
+            KeyInfo privateKey = new KeyInfo(
+                            "./src/test/java/com/alvarium/annotators/public.key",
+                            SignType.Ed25519);
+            KeyInfo publicKey = new KeyInfo(
+                            "./src/test/java/com/alvarium/annotators/public.key",
+                            SignType.Ed25519);
+            SignatureInfo sign = new SignatureInfo(publicKey, privateKey);
+
+            final AnnotationType[] annotators = { AnnotationType.CHECKSUM };
+            final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
+
+            Annotator annotator = factory.getAnnotator(AnnotationType.CHECKSUM, config);
+            
+            // Generate dummy artifact and generate checksum
+            
+            final File artifactFile = dir.newFile("artifact");
+            Files.write(artifactFile.toPath(), "foo".getBytes());
+            
+            final File checksumFile = dir.newFile("checksum");
+            
+            final HashProvider hash = new HashProviderFactory().getProvider(config.getHash().getType());
+            final String checksum = hash.derive(
+                Files.readAllBytes(artifactFile.toPath())
+            );
+
+            Files.write(checksumFile.toPath(), checksum.getBytes());
+
+            System.out.println(checksum);
+            final ChecksumAnnotatorProps props = new ChecksumAnnotatorProps(
+                    artifactFile.toPath().toString(),
+                    checksumFile.toPath().toString()
+            );
+
+            PropertyBag ctx = new ImmutablePropertyBag(
+                    Map.of(AnnotationType.CHECKSUM.name(), props)
+            );
+            
+            byte[] data = "pipeline1/1".getBytes();
+            Annotation annotation = annotator.execute(ctx, data);
+            System.out.println(annotation.toJson());
+            assert annotation.getIsSatisfied();
+
+            // change artifact checksum
+            Files.write(checksumFile.toPath(), "bar".getBytes()); 
+            
+            annotation = annotator.execute(ctx, data);
+            System.out.println(annotation.toJson());
+            assert !annotation.getIsSatisfied();
+
+
+    }
+
+}


### PR DESCRIPTION
* Add `ARTIFACT` annotator type
* Add `ArtifactAnnotatorProps` class that takes artifact and checksum paths
* Add `ArtifactAnnotator` implementation where it generates the checksum of an existing artifact and matches is against an existing checksum
* Add another signature for the hash provider's `update()` method where the offset and size of the bytes intended for hashing can be specified. This is useful when hashing large files in chunks to be able to handle the EOF case where not the entire buffer is hydrated