### PR TITLE
Change checksum annotator properties class name

### DIFF
--- a/src/main/java/com/alvarium/annotators/ChecksumAnnotatorProps.java
+++ b/src/main/java/com/alvarium/annotators/ChecksumAnnotatorProps.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package com.alvarium.annotators;
 
-public class ArtifactAnnotatorProps {
+public class ChecksumAnnotatorProps {
     final private String checksumPath;
     final private String artifactPath;
     
-    public ArtifactAnnotatorProps(String artifactPath, String checksumPath) {
+    public ChecksumAnnotatorProps(String artifactPath, String checksumPath) {
         this.artifactPath = artifactPath;
         this.checksumPath = checksumPath;
     }


### PR DESCRIPTION
Fix #106

Changed the `ArtifactAnnotatorProps` class name to `ChecksumAnnotatorProps`