### PR TITLE
Add support for annotator-speicific configuration

### DIFF
--- a/src/main/java/com/alvarium/DefaultSdk.java
+++ b/src/main/java/com/alvarium/DefaultSdk.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import com.alvarium.annotators.Annotator;
+import com.alvarium.annotators.AnnotatorConfig;
 import com.alvarium.annotators.AnnotatorException;
 import com.alvarium.annotators.AnnotatorFactory;
 import com.alvarium.contracts.Annotation;
@@ -68,8 +69,10 @@ public class DefaultSdk implements Sdk {
 
     // source annotate the old data
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
-    final Annotator sourceAnnotator = annotatorFactory.getAnnotator(AnnotationType.SOURCE,
-        this.config);
+    final Annotator sourceAnnotator = annotatorFactory.getAnnotator(
+        new AnnotatorConfig(AnnotationType.SOURCE),
+        this.config
+    );
     final Annotation sourceAnnotation = sourceAnnotator.execute(properties, oldData);
     annotations.add(sourceAnnotation);
 

--- a/src/main/java/com/alvarium/SdkInfo.java
+++ b/src/main/java/com/alvarium/SdkInfo.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,8 +16,9 @@ package com.alvarium;
 
 import java.io.Serializable;
 
-import com.alvarium.contracts.AnnotationType;
+import com.alvarium.annotators.AnnotatorConfig;
 import com.alvarium.hash.HashInfo;
+import com.alvarium.serializers.AnnotatorConfigConverter;
 import com.alvarium.serializers.StreamInfoConverter;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.streams.StreamInfo;
@@ -28,12 +29,12 @@ import com.google.gson.GsonBuilder;
  * A java bean that encapsulates sdk related configuration
  */
 public class SdkInfo implements Serializable {
-  private final AnnotationType[] annotators;
+  private final AnnotatorConfig[] annotators;
   private final HashInfo hash;
   private final SignatureInfo signature;
   private final StreamInfo stream;
 
-  public SdkInfo(AnnotationType[] annotators, HashInfo hash, SignatureInfo signature,
+  public SdkInfo(AnnotatorConfig[] annotators, HashInfo hash, SignatureInfo signature,
       StreamInfo stream) {
     this.annotators = annotators;
     this.hash = hash;
@@ -41,7 +42,7 @@ public class SdkInfo implements Serializable {
     this.stream = stream;
   }
 
-  public AnnotationType[] getAnnotators() {
+  public AnnotatorConfig[] getAnnotators() {
     return this.annotators;
   }
 
@@ -58,13 +59,17 @@ public class SdkInfo implements Serializable {
   }
 
   public String toJson() {
-    Gson gson = new GsonBuilder().registerTypeAdapter(StreamInfo.class, new StreamInfoConverter())
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapter(StreamInfo.class, new StreamInfoConverter())
+        .registerTypeAdapter(AnnotatorConfig.class, new AnnotatorConfigConverter())
         .create();
     return gson.toJson(this);
   }
 
   public static SdkInfo fromJson(String json) {
-    Gson gson = new GsonBuilder().registerTypeAdapter(StreamInfo.class, new StreamInfoConverter())
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapter(StreamInfo.class, new StreamInfoConverter())
+        .registerTypeAdapter(AnnotatorConfig.class, new AnnotatorConfigConverter())
         .create();
     return gson.fromJson(json, SdkInfo.class);
   }

--- a/src/main/java/com/alvarium/annotators/AnnotatorConfig.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorConfig.java
@@ -1,0 +1,33 @@
+
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.alvarium.annotators;
+
+import java.io.Serializable;
+
+import com.alvarium.contracts.AnnotationType;
+
+public class AnnotatorConfig implements Serializable {
+    private AnnotationType kind;
+
+    public AnnotatorConfig(AnnotationType kind) {
+        this.kind = kind;
+    }
+
+    public AnnotationType getKind() {
+        return this.kind;
+    }
+
+}

--- a/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
@@ -14,18 +14,22 @@
 package com.alvarium.annotators;
 
 import com.alvarium.SdkInfo;
-import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
 
 public class AnnotatorFactory {
 
-  public Annotator getAnnotator(AnnotationType kind, SdkInfo config) throws AnnotatorException {
+  public Annotator getAnnotator(AnnotatorConfig cfg, SdkInfo config) throws AnnotatorException {
     final HashType hash = config.getHash().getType();
     final SignatureInfo signature = config.getSignature();
-    switch (kind) {
+    switch (cfg.getKind()) {
       case MOCK:
-        return new MockAnnotator(hash, kind, signature);
+        try {
+            MockAnnotatorConfig mockCfg = MockAnnotatorConfig.class.cast(cfg);
+            return new MockAnnotator(mockCfg, hash, signature);
+        } catch(ClassCastException e) {
+            throw new AnnotatorException("Invalid annotator config", e);
+        }
       case TLS:
         return new TlsAnnotator(hash, signature);
       case PKI:

--- a/src/main/java/com/alvarium/annotators/MockAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/MockAnnotator.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,13 +30,15 @@ import com.alvarium.utils.PropertyBag;
  * a dummy annotator to be used in unit tests
  */
 class MockAnnotator implements Annotator {
+  private final MockAnnotatorConfig cfg;
   private final HashType hash;
   private final AnnotationType kind;
   private final SignatureInfo signature;
 
-  protected MockAnnotator(HashType hash, AnnotationType kind, SignatureInfo signature) {
+  protected MockAnnotator(MockAnnotatorConfig cfg, HashType hash, SignatureInfo signature) {
+    this.cfg = cfg;
     this.hash = hash;
-    this.kind = kind;
+    this.kind = AnnotationType.MOCK;
     this.signature = signature;
   }
 
@@ -47,7 +49,7 @@ class MockAnnotator implements Annotator {
       final String host = InetAddress.getLocalHost().getHostName();
       final String sig = signature.getPublicKey().getType().toString();
 
-      final Annotation annotation = new Annotation(key, hash, host, kind, sig, true, Instant.now());
+      final Annotation annotation = new Annotation(key, hash, host, kind, sig, cfg.getShouldSatisfy(), Instant.now());
       return annotation;
     } catch (HashTypeException e) {
       throw new AnnotatorException("failed to hash data", e);

--- a/src/main/java/com/alvarium/annotators/MockAnnotatorConfig.java
+++ b/src/main/java/com/alvarium/annotators/MockAnnotatorConfig.java
@@ -1,0 +1,35 @@
+
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.alvarium.annotators;
+
+
+
+import com.alvarium.contracts.AnnotationType;
+
+public class MockAnnotatorConfig extends AnnotatorConfig {
+    private final boolean shouldSatisfy;
+
+    MockAnnotatorConfig(boolean shouldSatisfy) {
+        super(AnnotationType.MOCK);
+        this.shouldSatisfy = shouldSatisfy;
+    }
+
+    public boolean getShouldSatisfy() {
+        return this.shouldSatisfy;
+    }
+
+
+}

--- a/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
@@ -37,6 +37,8 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
     final SignatureInfo sign;
     final AnnotationType kind;
 
+    private PackageFileHandler packageHandler;
+
     protected VulnerabilityAnnotator(HashType hash, SignatureInfo signature) {
         this.hash = hash;
         this.sign = signature;
@@ -81,8 +83,8 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
     
     private Map<String, String> getPackages(String dir) throws AnnotatorException {
         try {
-            final PackageFileHandler handler = new PackageFileHandlerFactory().getHandler(dir);
-            return handler.getPackages();
+            this.packageHandler = new PackageFileHandlerFactory().getHandler(dir);
+            return this.packageHandler.getPackages();
         } catch (VulnerabilityException e) {
             throw new AnnotatorException("Failed to get dependency info", e);
         } catch (Exception e) {

--- a/src/main/java/com/alvarium/serializers/AnnotatorConfigConverter.java
+++ b/src/main/java/com/alvarium/serializers/AnnotatorConfigConverter.java
@@ -1,0 +1,55 @@
+
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.alvarium.serializers;
+
+import java.lang.reflect.Type;
+
+
+import com.alvarium.annotators.AnnotatorConfig;
+import com.alvarium.annotators.MockAnnotatorConfig;
+import com.alvarium.contracts.AnnotationType;
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class AnnotatorConfigConverter implements JsonDeserializer<AnnotatorConfig> {
+    
+    public AnnotatorConfig deserialize(
+            JsonElement json, 
+            Type typeOfT, 
+            JsonDeserializationContext context
+    ) {
+        JsonObject obj = json.getAsJsonObject();
+        if (!obj.has("kind")) {
+            throw new IllegalArgumentException("Annotator config entry does not specify kind");
+        }
+        Gson gson = new Gson();
+        AnnotationType kind = gson.fromJson(obj.getAsJsonPrimitive("kind"), AnnotationType.class);
+        if (kind == null) {
+            throw new IllegalArgumentException("Invalid annotator kind provided in config");
+        }
+        switch (kind) {
+            case MOCK:
+                MockAnnotatorConfig mockCfg = gson.fromJson(obj.toString(), MockAnnotatorConfig.class);
+                return mockCfg;
+            default: 
+                return gson.fromJson(json, AnnotatorConfig.class);
+        }
+    }
+}
+

--- a/src/test/java/com/alvarium/SdkInfoTest.java
+++ b/src/test/java/com/alvarium/SdkInfoTest.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,14 +14,13 @@
  *******************************************************************************/
 package com.alvarium;
 
-import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Arrays;
 
+import com.alvarium.annotators.MockAnnotatorConfig;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignType;
@@ -31,7 +30,6 @@ import org.junit.Test;
 
 public class SdkInfoTest {
   private final String testJson;
-  private final AnnotationType[] annotators = {AnnotationType.TLS,AnnotationType.MOCK};
 
   public SdkInfoTest() throws IOException {
     String path = "./src/test/java/com/alvarium/sdk-info.json";
@@ -42,9 +40,17 @@ public class SdkInfoTest {
   public void fromJsonShouldReturnSdkInfo(){
     SdkInfo sdkInfo = SdkInfo.fromJson(this.testJson);
 
-    assertEquals(true, Arrays.equals(this.annotators, sdkInfo.getAnnotators()));
-    assertEquals(HashType.SHA256Hash, sdkInfo.getHash().getType());
-    assertEquals(SignType.Ed25519, sdkInfo.getSignature().getPrivateKey().getType());
-    assertEquals(MqttConfig.class, sdkInfo.getStream().getConfig().getClass());
+    assert sdkInfo.getAnnotators().length == 2;
+
+    assert sdkInfo.getAnnotators()[0].getKind() == AnnotationType.TPM;
+
+    assert sdkInfo.getAnnotators()[1].getKind() == AnnotationType.MOCK;
+    assert MockAnnotatorConfig.class.cast(sdkInfo.getAnnotators()[1]).getShouldSatisfy() == false;
+
+
+    assert sdkInfo.getHash().getType() == HashType.SHA256Hash;
+    assert sdkInfo.getSignature().getPrivateKey().getType() == SignType.Ed25519;
+    assert sdkInfo.getStream().getConfig().getClass() == MqttConfig.class;
+
   } 
 }

--- a/src/test/java/com/alvarium/annotators/ChecksumAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/ChecksumAnnotatorTest.java
@@ -30,11 +30,14 @@ import com.alvarium.hash.HashProvider;
 import com.alvarium.hash.HashProviderFactory;
 import com.alvarium.hash.HashType;
 import com.alvarium.hash.HashTypeException;
+import com.alvarium.serializers.AnnotatorConfigConverter;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.ImmutablePropertyBag;
 import com.alvarium.utils.PropertyBag;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 public class ChecksumAnnotatorTest {
     @Rule
@@ -52,10 +55,18 @@ public class ChecksumAnnotatorTest {
                             SignType.Ed25519);
             SignatureInfo sign = new SignatureInfo(publicKey, privateKey);
 
-            final AnnotationType[] annotators = { AnnotationType.CHECKSUM };
-            final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
+            final Gson gson = new GsonBuilder()
+                .registerTypeAdapter(AnnotatorConfig.class, new AnnotatorConfigConverter())
+                .create();
+            final String cfgJson = "{\"kind\": \"checksum\"}";
+            final AnnotatorConfig checksumCfg = gson.fromJson(
+                        cfgJson, 
+                        AnnotatorConfig.class
+            );
 
-            Annotator annotator = factory.getAnnotator(AnnotationType.CHECKSUM, config);
+            final AnnotatorConfig[] annotators = {checksumCfg};  
+            final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
+            Annotator annotator = factory.getAnnotator(checksumCfg, config);
             
             // Generate dummy artifact and generate checksum
             

--- a/src/test/java/com/alvarium/annotators/PkiAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/PkiAnnotatorTest.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,14 +18,16 @@ import java.util.HashMap;
 
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
+import com.alvarium.serializers.AnnotatorConfigConverter;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.ImmutablePropertyBag;
 import com.alvarium.utils.PropertyBag;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import org.junit.Test;
 
@@ -33,6 +35,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class PkiAnnotatorTest {
+
+  
+
   @Test
   public void executeShouldGetSatisfiedAnnotation() throws AnnotatorException {
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
@@ -50,9 +55,11 @@ public class PkiAnnotatorTest {
     final byte[] data = String.format("{seed: \"helloo\", signature: \"%s\"}", signature)
         .getBytes();
 
-    final AnnotationType[] annotators = {AnnotationType.PKI};
+
+    final AnnotatorConfig pkiCfg = this.getAnnotatorCfg();
+    final AnnotatorConfig[] annotators = {pkiCfg};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKI, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(pkiCfg, config);
     final Annotation annotation = annotator.execute(ctx, data);
     assertTrue("isSatisfied should be true", annotation.getIsSatisfied());
   }
@@ -74,11 +81,23 @@ public class PkiAnnotatorTest {
     final byte[] data = String.format("{seed: \"helloo\", signature: \"%s\"}", signature)
         .getBytes();
 
-    final AnnotationType[] annotators = {AnnotationType.PKI};
+    final AnnotatorConfig pkiCfg = this.getAnnotatorCfg();
+    final AnnotatorConfig[] annotators = {pkiCfg};   
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKI, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(pkiCfg, config);
 
     final Annotation annotation = annotator.execute(ctx, data);
     assertFalse("isSatisfied should be false", annotation.getIsSatisfied());
+  }
+
+  public AnnotatorConfig getAnnotatorCfg() {
+    final Gson gson = new GsonBuilder()
+      .registerTypeAdapter(AnnotatorConfig.class, new AnnotatorConfigConverter())
+      .create();    
+    final String json = "{\"kind\": \"pki\"}";
+    return gson.fromJson(
+                json, 
+                AnnotatorConfig.class
+    ); 
   }
 }

--- a/src/test/java/com/alvarium/annotators/PkiHttpAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/PkiHttpAnnotatorTest.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2022 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -28,11 +28,14 @@ import com.alvarium.contracts.AnnotationType;
 import com.alvarium.contracts.DerivedComponent;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
+import com.alvarium.serializers.AnnotatorConfigConverter;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.ImmutablePropertyBag;
 import com.alvarium.utils.PropertyBag;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -84,9 +87,10 @@ public class PkiHttpAnnotatorTest {
     map.put(AnnotationType.PKIHttp.name(), request);
     final PropertyBag ctx = new ImmutablePropertyBag(map);
 
-    final AnnotationType[] annotators = { AnnotationType.PKIHttp };
+    final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
+    final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKIHttp, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
     final Annotation annotation = annotator.execute(ctx, data);
     assertTrue("isSatisfied should be true", annotation.getIsSatisfied());
   }
@@ -112,9 +116,10 @@ public class PkiHttpAnnotatorTest {
     exceptionRule.expect(AnnotatorException.class);
     exceptionRule.expectMessage("Invalid key type invalid");
 
-    final AnnotationType[] annotators = { AnnotationType.PKIHttp };
+    final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
+    final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKIHttp, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
     annotator.execute(ctx, data);
   }
 
@@ -139,9 +144,10 @@ public class PkiHttpAnnotatorTest {
     exceptionRule.expect(AnnotatorException.class);
     exceptionRule.expectMessage("Failed to load public key");
 
-    final AnnotationType[] annotators = { AnnotationType.PKIHttp };
+    final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
+    final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKIHttp, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
     annotator.execute(ctx, data);
   }
 
@@ -161,10 +167,11 @@ public class PkiHttpAnnotatorTest {
     HashMap<String, Object> map = new HashMap<>();
     map.put(AnnotationType.PKIHttp.name(), request);
     final PropertyBag ctx = new ImmutablePropertyBag(map);
-
-    final AnnotationType[] annotators = { AnnotationType.PKIHttp };
+    
+    final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
+    final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKIHttp, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
     final Annotation annotation = annotator.execute(ctx, data);
     assertFalse("isSatisfied should be false", annotation.getIsSatisfied());
   }
@@ -186,10 +193,22 @@ public class PkiHttpAnnotatorTest {
     map.put(AnnotationType.PKIHttp.name(), request);
     final PropertyBag ctx = new ImmutablePropertyBag(map);
 
-    final AnnotationType[] annotators = { AnnotationType.PKIHttp };
+    final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
+    final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.PKIHttp, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
     final Annotation annotation = annotator.execute(ctx, data);
     assertFalse("isSatisfied should be false", annotation.getIsSatisfied());
+  }
+
+  public AnnotatorConfig getAnnotatorCfg() {
+    final Gson gson = new GsonBuilder()
+      .registerTypeAdapter(AnnotatorConfig.class, new AnnotatorConfigConverter())
+      .create();        
+    final String json = "{\"kind\": \"pki-http\"}";
+    return gson.fromJson(
+                json, 
+                AnnotatorConfig.class
+    ); 
   }
 }

--- a/src/test/java/com/alvarium/annotators/SourceAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/SourceAnnotatorTest.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,14 +19,16 @@ import java.util.HashMap;
 
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
+import com.alvarium.serializers.AnnotatorConfigConverter;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.ImmutablePropertyBag;
 import com.alvarium.utils.PropertyBag;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import org.junit.Test;
 
@@ -40,10 +42,20 @@ public class SourceAnnotatorTest {
     final KeyInfo privKey = new KeyInfo("./src/test/java/com/alvarium/annotators/private.key",
         SignType.Ed25519);
     final SignatureInfo sigInfo = new SignatureInfo(pubKey, privKey);
-    final AnnotationType[] annotators = { AnnotationType.SOURCE };
+
+    final Gson gson = new GsonBuilder()
+      .registerTypeAdapter(AnnotatorConfig.class, new AnnotatorConfigConverter())
+      .create();
+    final String json = "{\"kind\": \"src\"}";
+    final AnnotatorConfig annotatorInfo = gson.fromJson(
+                json, 
+                AnnotatorConfig.class
+    ); 
+    System.out.println("hello " + annotatorInfo.getKind());
+    final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
 
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.SOURCE, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
 
     // dummy data and empty prop bag
     final byte[] data = "test data".getBytes();

--- a/src/test/java/com/alvarium/annotators/SourceCodeAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/SourceCodeAnnotatorTest.java
@@ -37,11 +37,14 @@ import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashProvider;
 import com.alvarium.hash.HashProviderFactory;
 import com.alvarium.hash.HashType;
+import com.alvarium.serializers.AnnotatorConfigConverter;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.ImmutablePropertyBag;
 import com.alvarium.utils.PropertyBag;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 public class SourceCodeAnnotatorTest {
 
@@ -59,9 +62,18 @@ public class SourceCodeAnnotatorTest {
                                 SignType.Ed25519);
 
                 SignatureInfo sign = new SignatureInfo(publicKey, privateKey);
-                final AnnotationType[] annotators = { AnnotationType.SourceCode };
+                
+                final Gson gson = new GsonBuilder()
+                .registerTypeAdapter(AnnotatorConfig.class, new AnnotatorConfigConverter())
+                .create();
+                final String json = "{\"kind\": \"source-code\"}";
+                final AnnotatorConfig annotatorInfo = gson.fromJson(
+                            json, 
+                            AnnotatorConfig.class
+                );                 
+                final AnnotatorConfig[] annotators = {annotatorInfo};  
                 final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
-                Annotator annotator = factory.getAnnotator(AnnotationType.SourceCode, config);
+                Annotator annotator = factory.getAnnotator(annotatorInfo, config);
 
                 // Generate dummy source code directory and 
                 // generate checksum for dummy source code

--- a/src/test/java/com/alvarium/annotators/TlsAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/TlsAnnotatorTest.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,11 +26,14 @@ import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
+import com.alvarium.serializers.AnnotatorConfigConverter;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.ImmutablePropertyBag;
 import com.alvarium.utils.PropertyBag;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import org.junit.Test;
 
@@ -46,9 +49,18 @@ public class TlsAnnotatorTest {
     final KeyInfo privKey = new KeyInfo("./src/test/java/com/alvarium/annotators/private.key",
         SignType.Ed25519);
     final SignatureInfo sigInfo = new SignatureInfo(pubKey, privKey);
-    final AnnotationType[] annotators = { AnnotationType.TLS };
+    
+    final Gson gson = new GsonBuilder()
+      .registerTypeAdapter(AnnotatorConfig.class, new AnnotatorConfigConverter())
+      .create();
+    final String json = "{\"kind\": \"tls\"}";
+    final AnnotatorConfig annotatorInfo = gson.fromJson(
+                json, 
+                AnnotatorConfig.class
+    );      
+    final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.TLS, config); 
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config); 
     
     // dummy data
     final byte[] data = "test data".getBytes();

--- a/src/test/java/com/alvarium/annotators/TpmAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/TpmAnnotatorTest.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,14 +18,16 @@ import java.util.HashMap;
 
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
+import com.alvarium.serializers.AnnotatorConfigConverter;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.ImmutablePropertyBag;
 import com.alvarium.utils.PropertyBag;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import org.junit.Test;
 
@@ -42,9 +44,18 @@ public class TpmAnnotatorTest {
         SignType.Ed25519);
 
     SignatureInfo sign = new SignatureInfo(publicKey, privateKey);
-    final AnnotationType[] annotators = { AnnotationType.TPM };
+    final Gson gson = new GsonBuilder()
+      .registerTypeAdapter(AnnotatorConfig.class, new AnnotatorConfigConverter())
+      .create();
+    
+    final String json = "{\"kind\": \"tpm\"}";
+    final AnnotatorConfig annotatorInfo = gson.fromJson(
+                json, 
+                AnnotatorConfig.class
+    );       
+    final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
-    Annotator tpm = factory.getAnnotator(AnnotationType.TPM, config);
+    Annotator tpm = factory.getAnnotator(annotatorInfo, config);
     
     PropertyBag ctx = new ImmutablePropertyBag(new HashMap<String, Object>());
     

--- a/src/test/java/com/alvarium/annotators/VulnerabilityAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/VulnerabilityAnnotatorTest.java
@@ -23,11 +23,14 @@ import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
+import com.alvarium.serializers.AnnotatorConfigConverter;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.ImmutablePropertyBag;
 import com.alvarium.utils.PropertyBag;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -45,10 +48,12 @@ public class VulnerabilityAnnotatorTest {
     final KeyInfo privKey = new KeyInfo("./src/test/java/com/alvarium/annotators/private.key",
         SignType.Ed25519);
     final SignatureInfo sigInfo = new SignatureInfo(pubKey, privKey);
-    final AnnotationType[] annotators = { AnnotationType.VULNERABILITY};
+
+    final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
+    final AnnotatorConfig[] annotators = {annotatorInfo};
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
 
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.VULNERABILITY, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
     
     //Writing pom.xml file with a dependency that has a known vulnerability
     //Therefore a non satisfied annotation should be returned
@@ -90,10 +95,11 @@ public class VulnerabilityAnnotatorTest {
     final KeyInfo privKey = new KeyInfo("./src/test/java/com/alvarium/annotators/private.key",
         SignType.Ed25519);
     final SignatureInfo sigInfo = new SignatureInfo(pubKey, privKey);
-    final AnnotationType[] annotators = { AnnotationType.VULNERABILITY};
+    final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
+    final AnnotatorConfig[] annotators = {annotatorInfo};
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
 
-    final Annotator annotator = annotatorFactory.getAnnotator(AnnotationType.VULNERABILITY, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
     
     //Writing pom.xml file with a non existing dependency so there will be no exisitng vurnerabilities
     //Therefore a satisifed annotation should be returned
@@ -125,5 +131,16 @@ public class VulnerabilityAnnotatorTest {
     final Annotation annotation = annotator.execute(ctx, data);
 
     assert annotation.getIsSatisfied();
+  }
+
+  public AnnotatorConfig getAnnotatorCfg() {
+    final Gson gson = new GsonBuilder()
+      .registerTypeAdapter(AnnotatorConfig.class, new AnnotatorConfigConverter())
+      .create();
+    final String json = "{\"kind\": \"vulnerability\"}";
+    return gson.fromJson(
+                json, 
+                AnnotatorConfig.class
+    ); 
   }
 }

--- a/src/test/java/com/alvarium/mock-info.json
+++ b/src/test/java/com/alvarium/mock-info.json
@@ -1,6 +1,14 @@
 
 {
-  "annotators": ["mock", "mock"],
+  "annotators": [
+    {
+      "kind": "tpm"
+    },
+    {
+      "kind": "mock",
+      "shouldSatisfy": false
+    }    
+  ],
   "hash": {
     "type": "sha256"
   },

--- a/src/test/java/com/alvarium/sdk-info.json
+++ b/src/test/java/com/alvarium/sdk-info.json
@@ -1,5 +1,13 @@
 {
-  "annotators": ["tls", "mock"],
+  "annotators": [
+    {
+      "kind": "tpm"
+    },
+    {
+      "kind": "mock",
+      "shouldSatisfy": false
+    }
+  ],
   "hash": {
     "type": "sha256"
   },


### PR DESCRIPTION
Fix #110

* Add a new AnnotatorInfo class along with its deserializer and use it in place of annotator kind when instantiating annotators
* Adjust unit tests accordingly
* Enable the configuration of the MockAnnotator to be either satisfied or not satisfied
* Move the ServiceInfo class to a common package to enable future annotators that use external API's to use it