### PR TITLE
Fix possible issue in stream provider deserializer for complex names

### DIFF
--- a/src/main/java/com/alvarium/serializers/StreamInfoConverter.java
+++ b/src/main/java/com/alvarium/serializers/StreamInfoConverter.java
@@ -40,8 +40,9 @@ public class StreamInfoConverter implements JsonDeserializer<StreamInfo> {
         Type typeOfT, 
         JsonDeserializationContext context
     ) {
+    Gson gson = new Gson();
     JsonObject obj = json.getAsJsonObject();
-    StreamType type = StreamType.valueOf(obj.get("type").getAsString().toUpperCase());
+    StreamType type = gson.fromJson(obj.get("type"), StreamType.class);
     switch(type){
       case MQTT: 
         MqttConfig mqttConfig = MqttConfig.fromJson(obj.get("config").toString());
@@ -50,7 +51,6 @@ public class StreamInfoConverter implements JsonDeserializer<StreamInfo> {
         PravegaConfig pravegaConfig = PravegaConfig.fromJson(obj.get("config").toString());
         return new StreamInfo(type, pravegaConfig);
       default: 
-        Gson gson = new Gson();
         return gson.fromJson(json, StreamInfo.class);
     } 
   }


### PR DESCRIPTION
Fix #113

Used `gson.fromJson()` to deserialize the StreamType value in the StreamInfoConverter class to allow it to use the SerializedName decorator instead of bypassing it