### PR TITLE
Add capability to pass vulnerability source to annotator through config

### DIFF
--- a/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
@@ -14,6 +14,7 @@
 package com.alvarium.annotators;
 
 import com.alvarium.SdkInfo;
+import com.alvarium.annotators.vulnerability.VulnerabilityAnnotatorConfig;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
 
@@ -43,7 +44,8 @@ public class AnnotatorFactory {
       case CHECKSUM:
         return new ChecksumAnnotator(hash, signature);
       case VULNERABILITY:
-        return new VulnerabilityAnnotator(hash, signature);
+        VulnerabilityAnnotatorConfig vulnCfg = VulnerabilityAnnotatorConfig.class.cast(cfg);
+        return new VulnerabilityAnnotator(vulnCfg, hash, signature);
       case SOURCE:
         return new SourceAnnotator(hash, signature);
       default:

--- a/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import com.alvarium.annotators.vulnerability.PackageFileHandler;
 import com.alvarium.annotators.vulnerability.PackageFileHandlerFactory;
+import com.alvarium.annotators.vulnerability.VulnerabilityAnnotatorConfig;
 import com.alvarium.annotators.vulnerability.VulnerabilityApiHandler;
 import com.alvarium.annotators.vulnerability.VulnerabilityApiHandlerFactory;
 import com.alvarium.annotators.vulnerability.VulnerabilityException;
@@ -33,13 +34,19 @@ import com.alvarium.utils.PropertyBag;
 
 
 public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotator {
+    final VulnerabilityAnnotatorConfig cfg;
     final HashType hash;
     final SignatureInfo sign;
     final AnnotationType kind;
 
     private PackageFileHandler packageHandler;
 
-    protected VulnerabilityAnnotator(HashType hash, SignatureInfo signature) {
+    protected VulnerabilityAnnotator(
+        VulnerabilityAnnotatorConfig cfg, 
+        HashType hash, 
+        SignatureInfo signature
+    ) {
+        this.cfg = cfg;
         this.hash = hash;
         this.sign = signature;
         this.kind = AnnotationType.VULNERABILITY;
@@ -94,7 +101,8 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
     
     private List<String> retrievePackagesVulnerabilities( Map<String, String> packages) throws AnnotatorException {
         try{
-            final VulnerabilityApiHandler apiHandler = new VulnerabilityApiHandlerFactory().getHandler("osv"); //To replace with a var from config
+            final VulnerabilityApiHandler apiHandler = new VulnerabilityApiHandlerFactory()
+                .getHandler(this.cfg);
             List<String> vulnerabilities = apiHandler.getVulnerabilityIds(packages);
             return vulnerabilities;
         } catch (VulnerabilityException e) {

--- a/src/main/java/com/alvarium/annotators/vulnerability/OsvApiHandler.java
+++ b/src/main/java/com/alvarium/annotators/vulnerability/OsvApiHandler.java
@@ -30,17 +30,17 @@ import com.google.gson.Gson;
 
 public class OsvApiHandler implements VulnerabilityApiHandler {
     final private Gson gson = new Gson();
-    final private String endpoint;
+    final private VulnerabilityAnnotatorConfig cfg;
 
-    public OsvApiHandler() {
-        this.endpoint = "https://api.osv.dev/v1/querybatch";
+    public OsvApiHandler(VulnerabilityAnnotatorConfig cfg) {
+        this.cfg = cfg;
     }
 
     private OsvBatchResponse makeApiCall(Map<String,String> packages) throws VulnerabilityException {
         try {
             // Create the HTTP client and POST request
             CloseableHttpClient httpClient = HttpClients.createDefault();
-            HttpPost httpPost = new HttpPost(this.endpoint);
+            HttpPost httpPost = new HttpPost(this.cfg.getQueryBatchPath()); 
 
             // Set the request body
             OsvBatchRequest req = new OsvBatchRequest(packages);
@@ -56,7 +56,7 @@ public class OsvApiHandler implements VulnerabilityApiHandler {
             // Get the response body
             HttpEntity responseEntity = response.getEntity();
             String responseBody = responseEntity != null ? EntityUtils.toString(responseEntity) : null;
-            //JsonObject jsonResponse = gson.fromJson(responseBody, JsonObject.class);
+
             OsvBatchResponse responseBatch = gson.fromJson(responseBody, OsvBatchResponse.class);
 
             // Close the response and the client

--- a/src/main/java/com/alvarium/annotators/vulnerability/VulnerabilityAnnotatorConfig.java
+++ b/src/main/java/com/alvarium/annotators/vulnerability/VulnerabilityAnnotatorConfig.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.alvarium.annotators.vulnerability;
+
+
+import com.alvarium.annotators.AnnotatorConfig;
+import com.alvarium.contracts.AnnotationType;
+import com.alvarium.utils.ServiceInfo;
+
+
+public class VulnerabilityAnnotatorConfig extends AnnotatorConfig {
+
+    private final VulnerabilityProviderType type;
+    private final ServiceInfo provider;
+    private final EndpointPaths paths;
+    
+
+    VulnerabilityAnnotatorConfig(ServiceInfo provider, VulnerabilityProviderType type, EndpointPaths paths) {
+        super(AnnotationType.VULNERABILITY);
+        this.provider = provider;
+        this.type = type;
+        this.paths = paths;
+    }
+
+    public ServiceInfo getProvider() {
+        return this.provider;
+    }
+
+    public VulnerabilityProviderType getProviderType() {
+        return this.type;
+    }
+
+    public String getQueryBatchPath() {
+        return this.provider.uri() + this.paths.getBatchQuery();
+    }
+
+    public String getQueryPath() {
+        return this.provider.uri() + this.paths.getQuery();
+    }
+
+    /**
+     * Holder for the API's endpoint query paths
+     */
+    static class EndpointPaths {
+        private final String queryBatch;
+        private final String query;
+
+        public EndpointPaths(String queryBatch, String query) {
+            this.queryBatch = queryBatch;
+            this.query = query;
+        }
+
+        String getBatchQuery() {
+            return this.queryBatch;
+        }
+
+        String getQuery() {
+            return this.query;
+        }
+    } 
+    
+}

--- a/src/main/java/com/alvarium/annotators/vulnerability/VulnerabilityApiHandlerFactory.java
+++ b/src/main/java/com/alvarium/annotators/vulnerability/VulnerabilityApiHandlerFactory.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package com.alvarium.annotators.vulnerability;
 
-
 public class VulnerabilityApiHandlerFactory {
-    public VulnerabilityApiHandler getHandler(String apiProvider) throws VulnerabilityException {
+    public VulnerabilityApiHandler getHandler(VulnerabilityAnnotatorConfig cfg
+    ) throws VulnerabilityException {
         //switch case on apiProvider
-        switch (apiProvider) {
-            case "osv":
-                return new OsvApiHandler();
+        switch (cfg.getProviderType()) {
+            case OSV:
+                return new OsvApiHandler(cfg);
             default:
-                throw new VulnerabilityException("Could not find a supported vulnerability api provider");
+                throw new VulnerabilityException("Vulnerability api provider not found");
         }
     }
 }

--- a/src/main/java/com/alvarium/annotators/vulnerability/VulnerabilityProviderType.java
+++ b/src/main/java/com/alvarium/annotators/vulnerability/VulnerabilityProviderType.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.alvarium.annotators.vulnerability;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum VulnerabilityProviderType {
+    @SerializedName("osv")
+    OSV
+}

--- a/src/main/java/com/alvarium/serializers/AnnotatorConfigConverter.java
+++ b/src/main/java/com/alvarium/serializers/AnnotatorConfigConverter.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 
 import com.alvarium.annotators.AnnotatorConfig;
 import com.alvarium.annotators.MockAnnotatorConfig;
+import com.alvarium.annotators.vulnerability.VulnerabilityAnnotatorConfig;
 import com.alvarium.contracts.AnnotationType;
 import com.google.gson.Gson;
 import com.google.gson.JsonDeserializationContext;
@@ -47,6 +48,12 @@ public class AnnotatorConfigConverter implements JsonDeserializer<AnnotatorConfi
             case MOCK:
                 MockAnnotatorConfig mockCfg = gson.fromJson(obj.toString(), MockAnnotatorConfig.class);
                 return mockCfg;
+            case VULNERABILITY:
+                VulnerabilityAnnotatorConfig vulnCfg = gson.fromJson(
+                    obj, 
+                    VulnerabilityAnnotatorConfig.class
+                );
+                return vulnCfg;
             default: 
                 return gson.fromJson(json, AnnotatorConfig.class);
         }

--- a/src/main/java/com/alvarium/streams/MqttConfig.java
+++ b/src/main/java/com/alvarium/streams/MqttConfig.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,6 +16,7 @@ package com.alvarium.streams;
 
 import java.io.Serializable;
 
+import com.alvarium.utils.ServiceInfo;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 

--- a/src/main/java/com/alvarium/streams/PravegaConfig.java
+++ b/src/main/java/com/alvarium/streams/PravegaConfig.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,6 +16,7 @@ package com.alvarium.streams;
 
 import java.io.Serializable;
 
+import com.alvarium.utils.ServiceInfo;
 import com.google.gson.Gson;
 
 /**

--- a/src/main/java/com/alvarium/utils/ServiceInfo.java
+++ b/src/main/java/com/alvarium/utils/ServiceInfo.java
@@ -1,6 +1,6 @@
 
 /*******************************************************************************
- * Copyright 2021 Dell Inc.
+ * Copyright 2023 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  *******************************************************************************/
-package com.alvarium.streams;
+package com.alvarium.utils;
 
 import java.io.Serializable;
 
@@ -26,7 +26,7 @@ public class ServiceInfo implements Serializable {
   private final String protocol;
   private final int port;
 
-  protected ServiceInfo(String host, String protocol, int port) {
+  public ServiceInfo(String host, String protocol, int port) {
     this.host = host;
     this.protocol = protocol;
     this.port = port;

--- a/src/test/java/com/alvarium/SdkInfoTest.java
+++ b/src/test/java/com/alvarium/SdkInfoTest.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import com.alvarium.annotators.MockAnnotatorConfig;
+import com.alvarium.annotators.vulnerability.VulnerabilityAnnotatorConfig;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignType;
@@ -40,7 +41,7 @@ public class SdkInfoTest {
   public void fromJsonShouldReturnSdkInfo(){
     SdkInfo sdkInfo = SdkInfo.fromJson(this.testJson);
 
-    assert sdkInfo.getAnnotators().length == 2;
+    assert sdkInfo.getAnnotators().length == 3;
 
     assert sdkInfo.getAnnotators()[0].getKind() == AnnotationType.TPM;
 
@@ -48,6 +49,22 @@ public class SdkInfoTest {
     assert MockAnnotatorConfig.class.cast(sdkInfo.getAnnotators()[1]).getShouldSatisfy() == false;
 
 
+    assert sdkInfo.getAnnotators()[2].getKind() == AnnotationType.VULNERABILITY;
+    assert VulnerabilityAnnotatorConfig.class.cast(sdkInfo.getAnnotators()[2])
+      .getProvider()
+      .uri()
+      .equals("https://example.com:80");
+
+    assert VulnerabilityAnnotatorConfig.class.cast(sdkInfo.getAnnotators()[2])
+      .getQueryBatchPath()
+      .equals("https://example.com:80/v1/querybatch");
+
+    assert VulnerabilityAnnotatorConfig.class.cast(sdkInfo.getAnnotators()[2])
+      .getQueryPath()
+      .equals("https://example.com:80/v1/query");
+
+
+    
     assert sdkInfo.getHash().getType() == HashType.SHA256Hash;
     assert sdkInfo.getSignature().getPrivateKey().getType() == SignType.Ed25519;
     assert sdkInfo.getStream().getConfig().getClass() == MqttConfig.class;

--- a/src/test/java/com/alvarium/annotators/vulnerability/OsvApiHandlerTest.java
+++ b/src/test/java/com/alvarium/annotators/vulnerability/OsvApiHandlerTest.java
@@ -18,11 +18,20 @@ import java.util.List;
 import java.util.Map;
 
 
-
+import com.alvarium.utils.ServiceInfo;
 
 public class OsvApiHandlerTest {
+    // @Test
     public void testGetVulnerabilityIds() throws VulnerabilityException {
-        OsvApiHandler batchResponse = new OsvApiHandler();
+        final ServiceInfo osvApi = new ServiceInfo("api.osv.dev", "https", 443);
+
+        OsvApiHandler batchResponse = new OsvApiHandler(
+            new VulnerabilityAnnotatorConfig(
+                osvApi,
+                VulnerabilityProviderType.OSV,
+                new VulnerabilityAnnotatorConfig.EndpointPaths("/v1/querybatch", "/v1/query")
+            )
+        );
 
         Map<String, String> packages = new HashMap<String, String>();
         packages.put("org.eclipse.jetty:jetty-server","7.0.0.M0");

--- a/src/test/java/com/alvarium/annotators/vulnerability/VulnerabilityApiHandlerFactoryTest.java
+++ b/src/test/java/com/alvarium/annotators/vulnerability/VulnerabilityApiHandlerFactoryTest.java
@@ -15,24 +15,21 @@ package com.alvarium.annotators.vulnerability;
 
 import org.junit.Test;
 
+import com.alvarium.utils.ServiceInfo;
+
 public class VulnerabilityApiHandlerFactoryTest {
 
     @Test
     public void shouldReturnOsvApiHandler() throws Exception {
-        String apiProvider = "osv";
+        VulnerabilityProviderType apiProvider = VulnerabilityProviderType.OSV;
         VulnerabilityApiHandlerFactory factory = new VulnerabilityApiHandlerFactory();
-        VulnerabilityApiHandler apiHandler = factory.getHandler(apiProvider);
+        VulnerabilityApiHandler apiHandler = factory.getHandler(
+            new VulnerabilityAnnotatorConfig(
+                new ServiceInfo("example.com", "hhttps", 80),
+                apiProvider,
+                new VulnerabilityAnnotatorConfig.EndpointPaths("/v1/querybatch", "/v1/query")
+            )
+        );
         assert apiHandler instanceof OsvApiHandler;
-    }
-    @Test
-    public void shouldThrowDependenciesExceptionForInvalidApiProvider() {
-        String apiProvider = "invalid_provider";
-        VulnerabilityApiHandlerFactory factory = new VulnerabilityApiHandlerFactory();
-        try {
-            factory.getHandler(apiProvider);
-            assert false : "Expected DependenciesException to be thrown";
-        } catch (VulnerabilityException e) {
-            assert true;
-        }
     }
 }

--- a/src/test/java/com/alvarium/sdk-info.json
+++ b/src/test/java/com/alvarium/sdk-info.json
@@ -6,6 +6,19 @@
     {
       "kind": "mock",
       "shouldSatisfy": false
+    },    
+    {
+      "kind": "vulnerability",
+      "type": "osv",
+      "paths": {
+        "queryBatch": "/v1/querybatch",
+        "query": "/v1/query"
+      },
+      "provider": {
+        "host": "example.com",
+        "port": 80,
+        "protocol": "https"
+      }
     }
   ],
   "hash": {


### PR DESCRIPTION
Fix #114

* Add new VulnerabilityAnnotatorConfig type and hydrate it from the SDK config
* Move ServiceInfo to contracts for use by multiple packages