### PR TITLE
Refactor Annotators to continue execution on error

### DIFF
--- a/src/main/java/com/alvarium/DefaultSdk.java
+++ b/src/main/java/com/alvarium/DefaultSdk.java
@@ -71,7 +71,8 @@ public class DefaultSdk implements Sdk {
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
     final Annotator sourceAnnotator = annotatorFactory.getAnnotator(
         new AnnotatorConfig(AnnotationType.SOURCE),
-        this.config
+        this.config,
+        this.logger
     );
     final Annotation sourceAnnotation = sourceAnnotator.execute(properties, oldData);
     annotations.add(sourceAnnotation);

--- a/src/main/java/com/alvarium/annotators/AbstractAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/AbstractAnnotator.java
@@ -18,6 +18,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import org.apache.logging.log4j.Logger;
+
 import com.alvarium.contracts.Annotation;
 import com.alvarium.hash.HashProvider;
 import com.alvarium.hash.HashProviderFactory;
@@ -34,6 +36,16 @@ import com.alvarium.utils.Encoder;
  */
 abstract class AbstractAnnotator {
 
+  protected  Logger logger;
+
+  AbstractAnnotator(Logger logger) {
+    this.logger = logger;
+  }
+
+  public Logger getLogger() {
+    return logger;
+  }
+  
   /**
    * returns hash of the provided data depending on the given hash type
    * @param type

--- a/src/main/java/com/alvarium/annotators/AbstractPkiAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/AbstractPkiAnnotator.java
@@ -5,6 +5,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import org.apache.logging.log4j.Logger;
+
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignException;
 import com.alvarium.sign.SignProvider;
@@ -12,6 +14,10 @@ import com.alvarium.sign.SignProviderFactory;
 import com.alvarium.utils.Encoder;
 
 abstract class AbstractPkiAnnotator extends AbstractAnnotator {
+  AbstractPkiAnnotator(Logger logger) {
+    super(logger);
+  }
+
   /**
    * Responsible for verifying the signature, returns true if the verification
    * passed, false otherwise.

--- a/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package com.alvarium.annotators;
 
+import org.apache.logging.log4j.Logger;
+
 import com.alvarium.SdkInfo;
 import com.alvarium.annotators.vulnerability.VulnerabilityAnnotatorConfig;
 import com.alvarium.hash.HashType;
@@ -20,7 +22,7 @@ import com.alvarium.sign.SignatureInfo;
 
 public class AnnotatorFactory {
 
-  public Annotator getAnnotator(AnnotatorConfig cfg, SdkInfo config) throws AnnotatorException {
+  public Annotator getAnnotator(AnnotatorConfig cfg, SdkInfo config, Logger logger) throws AnnotatorException {
     final HashType hash = config.getHash().getType();
     final SignatureInfo signature = config.getSignature();
     switch (cfg.getKind()) {
@@ -32,22 +34,22 @@ public class AnnotatorFactory {
             throw new AnnotatorException("Invalid annotator config", e);
         }
       case TLS:
-        return new TlsAnnotator(hash, signature);
+        return new TlsAnnotator(hash, signature, logger);
       case PKI:
-        return new PkiAnnotator(hash, signature);
+        return new PkiAnnotator(hash, signature, logger);
       case PKIHttp:
-        return new PkiHttpAnnotator(hash, signature);
+        return new PkiHttpAnnotator(hash, signature, logger);
       case TPM:
-        return new TpmAnnotator(hash, signature);
+        return new TpmAnnotator(hash, signature, logger);
       case SourceCode:
-        return new SourceCodeAnnotator(hash, signature);
+        return new SourceCodeAnnotator(hash, signature, logger);
       case CHECKSUM:
-        return new ChecksumAnnotator(hash, signature);
+        return new ChecksumAnnotator(hash, signature, logger);
       case VULNERABILITY:
         VulnerabilityAnnotatorConfig vulnCfg = VulnerabilityAnnotatorConfig.class.cast(cfg);
-        return new VulnerabilityAnnotator(vulnCfg, hash, signature);
+        return new VulnerabilityAnnotator(vulnCfg, hash, signature, logger);
       case SOURCE:
-        return new SourceAnnotator(hash, signature);
+        return new SourceAnnotator(hash, signature, logger);
       default:
         throw new AnnotatorException("Annotator type is not supported");
     }

--- a/src/main/java/com/alvarium/annotators/SourceAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/SourceAnnotator.java
@@ -18,6 +18,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Instant;
 
+import org.apache.logging.log4j.Logger;
+
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
@@ -33,7 +35,8 @@ class SourceAnnotator extends AbstractAnnotator implements Annotator {
   private final AnnotationType kind;
   private final SignatureInfo signatureInfo;
   
-  protected SourceAnnotator(HashType hash, SignatureInfo signatureInfo) {
+  protected SourceAnnotator(HashType hash, SignatureInfo signatureInfo, Logger logger) {
+    super(logger);
     this.hash = hash;
     this.kind = AnnotationType.SOURCE;
     this.signatureInfo = signatureInfo;
@@ -44,15 +47,19 @@ class SourceAnnotator extends AbstractAnnotator implements Annotator {
     final String key = super.deriveHash(this.hash, data);
 
     // get hostname if available
-    final String host;
+    String host = "";
+    boolean isSatisfied;
     try {
       host = InetAddress.getLocalHost().getHostName();
     } catch (UnknownHostException e) {
-      throw new AnnotatorException("cannot get host name.", e);
+      isSatisfied = false;
+      this.logger.error("Error during SourceAnnotator execution: ",e);
     }
 
+    isSatisfied = true;
+
     // create an annotation without signature
-    final Annotation annotation = new Annotation(key, this.hash, host, this.kind, null, true,
+    final Annotation annotation = new Annotation(key, this.hash, host, this.kind, null, isSatisfied,
         Instant.now());
     
     final String signature = super.signAnnotation(signatureInfo.getPrivateKey(), annotation);

--- a/src/main/java/com/alvarium/annotators/TlsAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/TlsAnnotator.java
@@ -17,6 +17,9 @@ package com.alvarium.annotators;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import javax.net.ssl.SSLSocket;
+
+import org.apache.logging.log4j.Logger;
+
 import java.time.Instant;
 
 import com.alvarium.contracts.Annotation;
@@ -30,7 +33,8 @@ class TlsAnnotator extends AbstractAnnotator implements Annotator {
   private final AnnotationType kind;
   private final SignatureInfo signatureInfo;
   
-  protected TlsAnnotator(HashType hash, SignatureInfo signatureInfo) {
+  protected TlsAnnotator(HashType hash, SignatureInfo signatureInfo, Logger logger) {
+    super(logger);
     this.hash = hash;
     this.kind = AnnotationType.TLS;
     this.signatureInfo = signatureInfo;
@@ -51,11 +55,11 @@ class TlsAnnotator extends AbstractAnnotator implements Annotator {
     final String key = super.deriveHash(hash, data);
 
     // get host name
-    String host;
+    String host = "";
     try {
       host = InetAddress.getLocalHost().getHostName();
     } catch (UnknownHostException e) {
-      throw new AnnotatorException("cannot get host name.", e);
+      this.logger.error("Error during TlsAnnotator execution: ",e);
     }
 
     // TLS check handshake

--- a/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
@@ -19,6 +19,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.logging.log4j.Logger;
+
 import com.alvarium.annotators.vulnerability.PackageFileHandler;
 import com.alvarium.annotators.vulnerability.PackageFileHandlerFactory;
 import com.alvarium.annotators.vulnerability.VulnerabilityAnnotatorConfig;
@@ -44,8 +46,10 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
     protected VulnerabilityAnnotator(
         VulnerabilityAnnotatorConfig cfg, 
         HashType hash, 
-        SignatureInfo signature
+        SignatureInfo signature,
+        Logger logger
     ) {
+        super(logger);
         this.cfg = cfg;
         this.hash = hash;
         this.sign = signature;
@@ -55,19 +59,22 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
     @Override
     public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
         final String key = super.deriveHash(hash, data);
-    
-        String host;
-        try {
-          host = InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-          throw new AnnotatorException("Cannot get host name", e);
-        }  
 
         String dir = ctx.getProperty(AnnotationType.VULNERABILITY.name(), String.class);
         Map<String, String> packages = getPackages(dir);
+        
+        List<String> vulnerabilities;
+        boolean isSatisfied;
+        String host = "";
+        try{
+            host = InetAddress.getLocalHost().getHostName();
 
-        List<String> vulnerabilities = retrievePackagesVulnerabilities(packages);
-        final boolean isSatisfied = vulnerabilities.size()==0; // TODO (Omar Eissa): Add satisfaction logic
+            vulnerabilities = retrievePackagesVulnerabilities(packages);
+            isSatisfied = vulnerabilities.isEmpty();
+        } catch (UnknownHostException | AnnotatorException e) {
+            isSatisfied = false;
+            this.logger.error("Error during VulnerabilityAnnotator execution: ",e);
+        }
         
         final Annotation annotation = new Annotation(
             key, 

--- a/src/test/java/com/alvarium/SdkTest.java
+++ b/src/test/java/com/alvarium/SdkTest.java
@@ -74,13 +74,13 @@ public class SdkTest {
     final Annotator[] annotators = new Annotator[sdkInfo.getAnnotators().length]; 
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
 
-    for (int i = 0; i < annotators.length; i++) {
-      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo);
-    }
-
     // init logger
     final Logger logger = LogManager.getRootLogger();
     Configurator.setRootLevel(Level.DEBUG);
+
+    for (int i = 0; i < annotators.length; i++) {
+      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo, logger);
+    }
 
     final Sdk sdk = new DefaultSdk(annotators, sdkInfo, logger);
     sdk.close();
@@ -104,13 +104,14 @@ public class SdkTest {
     final Annotator[] annotators = new Annotator[sdkInfo.getAnnotators().length];
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
 
-    for (int i = 0; i < annotators.length; i++) {
-      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo); 
-    }
-
-    // init logger and sdk
+    // init logger
     final Logger logger = LogManager.getRootLogger();
     Configurator.setRootLevel(Level.DEBUG);
+
+    for (int i = 0; i < annotators.length; i++) {
+      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo, logger); 
+    }
+
     final Sdk sdk = new DefaultSdk(annotators, sdkInfo, logger);
 
     final byte[] data = "test data".getBytes();
@@ -127,14 +128,15 @@ public class SdkTest {
     // init annotators
     final Annotator[] annotators = new Annotator[sdkInfo.getAnnotators().length];
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
-
-    for (int i = 0; i < annotators.length; i++) {
-      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo); 
-    }
-
-    // init logger and sdk
+    
+    // init logger
     final Logger logger = LogManager.getRootLogger();
     Configurator.setRootLevel(Level.DEBUG);
+
+    for (int i = 0; i < annotators.length; i++) {
+      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo, logger); 
+    }
+
     final Sdk sdk = new DefaultSdk(annotators, sdkInfo, logger);
 
     final byte[] data = "test data".getBytes();
@@ -151,13 +153,14 @@ public class SdkTest {
     final Annotator[] annotators = new Annotator[sdkInfo.getAnnotators().length];
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
 
-    for (int i = 0; i < annotators.length; i++) {
-      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo); 
-    }
-
-    // init logger and sdk
+    // init logger
     final Logger logger = LogManager.getRootLogger();
     Configurator.setRootLevel(Level.DEBUG);
+
+    for (int i = 0; i < annotators.length; i++) {
+      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo, logger); 
+    }
+
     final Sdk sdk = new DefaultSdk(annotators, sdkInfo, logger);
 
 
@@ -177,13 +180,14 @@ public class SdkTest {
     final Annotator[] annotators = new Annotator[sdkInfo.getAnnotators().length];
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
 
-    for (int i = 0; i < annotators.length; i++) {
-      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo); 
-    }
-
-    // init logger and sdk
+    // init logger
     final Logger logger = LogManager.getRootLogger();
     Configurator.setRootLevel(Level.DEBUG);
+
+    for (int i = 0; i < annotators.length; i++) {
+      annotators[i] = annotatorFactory.getAnnotator(sdkInfo.getAnnotators()[i], sdkInfo, logger); 
+    }
+
     final Sdk sdk = new DefaultSdk(annotators, sdkInfo, logger);
 
     final byte[] data = "test data".getBytes();

--- a/src/test/java/com/alvarium/annotators/AnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/AnnotatorTest.java
@@ -29,6 +29,10 @@ import com.alvarium.utils.PropertyBag;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.Test;
 
 public class AnnotatorTest {
@@ -73,17 +77,20 @@ public class AnnotatorTest {
     final AnnotatorConfig[] annotators = {satisfiedAnnotatorInfo, unsatisfiedAnnotatorInfo};
     final SdkInfo config = new SdkInfo(annotators, hash, signature, null);
 
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
+
     final AnnotatorFactory factory = new AnnotatorFactory();
-    final Annotator satisfiedAnnotator = factory.getAnnotator(satisfiedAnnotatorInfo, config);
-    final Annotator unsatisfiedAnnotator = factory.getAnnotator(unsatisfiedAnnotatorInfo, config);
+    final Annotator satisfiedAnnotator = factory.getAnnotator(satisfiedAnnotatorInfo, config, logger);
+    final Annotator unsatisfiedAnnotator = factory.getAnnotator(unsatisfiedAnnotatorInfo, config, logger);
 
     final byte[] data = "test data".getBytes();
     final PropertyBag ctx = new ImmutablePropertyBag(new HashMap<>());
+
     final Annotation satisfiedAnnotation = satisfiedAnnotator.execute(ctx, data);
     final Annotation unsatisfiedAnnotation = unsatisfiedAnnotator.execute(ctx, data);
 
     assert satisfiedAnnotation.getIsSatisfied();
     assert !unsatisfiedAnnotation.getIsSatisfied();
-
   }  
 }

--- a/src/test/java/com/alvarium/annotators/ChecksumAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/ChecksumAnnotatorTest.java
@@ -18,6 +18,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Map;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -66,7 +70,11 @@ public class ChecksumAnnotatorTest {
 
             final AnnotatorConfig[] annotators = {checksumCfg};  
             final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
-            Annotator annotator = factory.getAnnotator(checksumCfg, config);
+
+            // init logger
+            final Logger logger = LogManager.getRootLogger();
+            Configurator.setRootLevel(Level.DEBUG);
+            Annotator annotator = factory.getAnnotator(checksumCfg, config, logger);
             
             // Generate dummy artifact and generate checksum
             

--- a/src/test/java/com/alvarium/annotators/PkiAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/PkiAnnotatorTest.java
@@ -29,6 +29,10 @@ import com.alvarium.utils.PropertyBag;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -47,6 +51,10 @@ public class PkiAnnotatorTest {
         SignType.Ed25519);
     final SignatureInfo sigInfo = new SignatureInfo(pubKey, privKey);
 
+        // init logger
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
+
     final PropertyBag ctx = new ImmutablePropertyBag(new HashMap<String, Object>());
 
     final String signature = "B9E41596541933DB7144CFBF72105E4E53F9493729CA66331A658B1B18AC6DF5DA991"
@@ -59,7 +67,7 @@ public class PkiAnnotatorTest {
     final AnnotatorConfig pkiCfg = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {pkiCfg};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(pkiCfg, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(pkiCfg, config, logger);
     final Annotation annotation = annotator.execute(ctx, data);
     assertTrue("isSatisfied should be true", annotation.getIsSatisfied());
   }
@@ -73,6 +81,10 @@ public class PkiAnnotatorTest {
         SignType.Ed25519);
     final SignatureInfo sigInfo = new SignatureInfo(pubKey, privKey);
 
+            // init logger
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
+
     final PropertyBag ctx = new ImmutablePropertyBag(new HashMap<String, Object>());
 
     final String signature = "A9E41596541933DB7144CFBF72105E4E53F9493729CA66331A658B1B18AC6DF5DA991"
@@ -84,7 +96,7 @@ public class PkiAnnotatorTest {
     final AnnotatorConfig pkiCfg = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {pkiCfg};   
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(pkiCfg, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(pkiCfg, config, logger);
 
     final Annotation annotation = annotator.execute(ctx, data);
     assertFalse("isSatisfied should be false", annotation.getIsSatisfied());

--- a/src/test/java/com/alvarium/annotators/PkiHttpAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/PkiHttpAnnotatorTest.java
@@ -39,6 +39,10 @@ import com.google.gson.GsonBuilder;
 
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -76,6 +80,9 @@ public class PkiHttpAnnotatorTest {
   @Test
   // Tests the Signature signed by the assembler
   public void testAnnotationOK() throws AnnotatorException, RequestHandlerException {
+            // init logger
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
     HttpPost request = getRequest(sigInfo);
     try {
       request.setEntity(new StringEntity("{key: \"test\"}"));
@@ -90,7 +97,7 @@ public class PkiHttpAnnotatorTest {
     final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     final Annotation annotation = annotator.execute(ctx, data);
     assertTrue("isSatisfied should be true", annotation.getIsSatisfied());
   }
@@ -100,6 +107,9 @@ public class PkiHttpAnnotatorTest {
     final String signatureInput = "\"@method\" \"@path\" \"@authority\" \"Content-Type\" " + 
     "\"Content-Length\";created=1646146637;keyid=\"public.key\";alg=\"invalid\"";
 
+            // init logger
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
     HttpPost request = getRequest(sigInfo);
     try {
       request.setEntity(new StringEntity("{key: \"test\"}"));
@@ -119,7 +129,7 @@ public class PkiHttpAnnotatorTest {
     final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     annotator.execute(ctx, data);
   }
 
@@ -127,6 +137,9 @@ public class PkiHttpAnnotatorTest {
   public void testKeyNotFound() throws AnnotatorException, RequestHandlerException {
     final String signatureInput = "\"@method\" \"@path\" \"@authority\" \"Content-Type\" " + 
     "\"Content-Length\";created=1646146637;keyid=\"invalid\";alg=\"ed25519\"";
+            // init logger
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
 
     HttpPost request = getRequest(sigInfo);
     try {
@@ -141,19 +154,21 @@ public class PkiHttpAnnotatorTest {
     map.put(AnnotationType.PKIHttp.name(), request);
     final PropertyBag ctx = new ImmutablePropertyBag(map);
 
-    exceptionRule.expect(AnnotatorException.class);
-    exceptionRule.expectMessage("Failed to load public key");
 
     final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
-    annotator.execute(ctx, data);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
+    Annotation annotation = annotator.execute(ctx, data);
+    assertFalse("isSatisfied should be false", annotation.getIsSatisfied());
   }
 
   @Test
   public void testEmptySignature() throws AnnotatorException, RequestHandlerException {
     final String signature = "";
+            // init logger
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
 
     HttpPost request = getRequest(sigInfo);
     try {
@@ -171,7 +186,7 @@ public class PkiHttpAnnotatorTest {
     final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     final Annotation annotation = annotator.execute(ctx, data);
     assertFalse("isSatisfied should be false", annotation.getIsSatisfied());
   }
@@ -181,6 +196,9 @@ public class PkiHttpAnnotatorTest {
     final String signature = "invalid";
 
     HttpPost request = getRequest(sigInfo);
+            // init logger
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
     try {
       request.setEntity(new StringEntity("{key: \"test\"}"));
     } catch (UnsupportedEncodingException e) {
@@ -196,7 +214,7 @@ public class PkiHttpAnnotatorTest {
     final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     final Annotation annotation = annotator.execute(ctx, data);
     assertFalse("isSatisfied should be false", annotation.getIsSatisfied());
   }

--- a/src/test/java/com/alvarium/annotators/SourceAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/SourceAnnotatorTest.java
@@ -30,6 +30,10 @@ import com.alvarium.utils.PropertyBag;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.Test;
 
 public class SourceAnnotatorTest {
@@ -55,7 +59,11 @@ public class SourceAnnotatorTest {
     final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
 
-    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
+            // init logger
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
+
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
 
     // dummy data and empty prop bag
     final byte[] data = "test data".getBytes();

--- a/src/test/java/com/alvarium/annotators/SourceCodeAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/SourceCodeAnnotatorTest.java
@@ -24,6 +24,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -73,7 +77,10 @@ public class SourceCodeAnnotatorTest {
                 );                 
                 final AnnotatorConfig[] annotators = {annotatorInfo};  
                 final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
-                Annotator annotator = factory.getAnnotator(annotatorInfo, config);
+                        // init logger
+                final Logger logger = LogManager.getRootLogger();
+                Configurator.setRootLevel(Level.DEBUG);
+                Annotator annotator = factory.getAnnotator(annotatorInfo, config, logger);
 
                 // Generate dummy source code directory and 
                 // generate checksum for dummy source code

--- a/src/test/java/com/alvarium/annotators/TlsAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/TlsAnnotatorTest.java
@@ -35,13 +35,19 @@ import com.alvarium.utils.PropertyBag;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.Test;
 
 public class TlsAnnotatorTest {
   @Test
   public void executeShouldReturnAnnotation() throws AnnotatorException, IOException,
       UnknownHostException {
-
+                // init logger
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
     // construct annotator
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
     final KeyInfo pubKey = new KeyInfo("./src/test/java/com/alvarium/annotators/public.key", 
@@ -60,7 +66,7 @@ public class TlsAnnotatorTest {
     );      
     final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
-    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config); 
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger); 
     
     // dummy data
     final byte[] data = "test data".getBytes();

--- a/src/test/java/com/alvarium/annotators/TpmAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/TpmAnnotatorTest.java
@@ -29,12 +29,19 @@ import com.alvarium.utils.PropertyBag;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.Test;
 
 public class TpmAnnotatorTest {
   
   @Test
   public void executeShouldCreateAnnotation() throws AnnotatorException {
+            // init logger
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
     AnnotatorFactory factory = new AnnotatorFactory();
     KeyInfo privateKey = new KeyInfo(
         "./src/test/java/com/alvarium/annotators/public.key",
@@ -55,7 +62,7 @@ public class TpmAnnotatorTest {
     );       
     final AnnotatorConfig[] annotators = {annotatorInfo};  
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
-    Annotator tpm = factory.getAnnotator(annotatorInfo, config);
+    Annotator tpm = factory.getAnnotator(annotatorInfo, config, logger);
     
     PropertyBag ctx = new ImmutablePropertyBag(new HashMap<String, Object>());
     

--- a/src/test/java/com/alvarium/annotators/VulnerabilityAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/VulnerabilityAnnotatorTest.java
@@ -32,6 +32,10 @@ import com.alvarium.utils.PropertyBag;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
@@ -41,6 +45,9 @@ public class VulnerabilityAnnotatorTest {
     public TemporaryFolder dir = new TemporaryFolder();
 
     public void executeShouldReturnAnnotation() throws AnnotatorException, IOException {
+                // init logger
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
     // construct annotator
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
     final KeyInfo pubKey = new KeyInfo("./src/test/java/com/alvarium/annotators/public.key", 
@@ -53,7 +60,7 @@ public class VulnerabilityAnnotatorTest {
     final AnnotatorConfig[] annotators = {annotatorInfo};
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
 
-    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     
     //Writing pom.xml file with a dependency that has a known vulnerability
     //Therefore a non satisfied annotation should be returned
@@ -88,6 +95,9 @@ public class VulnerabilityAnnotatorTest {
   }
 
     public void executeShouldReturnSatisfiedAnnotation() throws AnnotatorException, IOException {
+                // init logger
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
     // construct annotator
     final AnnotatorFactory annotatorFactory = new AnnotatorFactory();
     final KeyInfo pubKey = new KeyInfo("./src/test/java/com/alvarium/annotators/public.key", 
@@ -99,7 +109,7 @@ public class VulnerabilityAnnotatorTest {
     final AnnotatorConfig[] annotators = {annotatorInfo};
     final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
 
-    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config);
+    final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     
     //Writing pom.xml file with a non existing dependency so there will be no exisitng vurnerabilities
     //Therefore a satisifed annotation should be returned


### PR DESCRIPTION
Fix #111 
- Refactored all Annotators to continue execution when an error occurs, returning an unsatisfied Annotation.
- Pass the Logger to the Annotators execute method to log the thrown exceptions.
- Refactored tests that expected Annotators execute to throw an exception to expect an unsatisfied Annotation.

Notes:
- The host is defaulted to an empty string in case fetching the host name throws an error so we can return an unsatisfied annotation.
- While executing The PkiHttpAnnotator the http signature logic may throw exceptions that will halt the execution as there will be no key to sign the annotation.