### PR TITLE
Add support for go.mod files in VulnerabilityAnnotator

### DIFF
--- a/src/main/java/com/alvarium/annotators/vulnerability/GoModHandler.java
+++ b/src/main/java/com/alvarium/annotators/vulnerability/GoModHandler.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.alvarium.annotators.vulnerability;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class GoModHandler implements PackageFileHandler {
+    final private File file;
+
+    protected GoModHandler(String dir) {
+        this.file = new File(dir + "/" + "go.mod");
+    }
+
+    @Override
+    public String getFileName() {
+        return this.file.getName();
+    }
+
+    @Override
+    public Map<String, String> getPackages() throws VulnerabilityException {
+        Map<String, String> packages = new HashMap<>();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            String line;
+            boolean inRequireBlock = false;
+            boolean inReplaceBlock = false;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (this.isRequireBlock(line)) {
+                    inRequireBlock = true;
+                    continue;
+                }
+                if (this.isReplaceBlock(line)) {
+                    inReplaceBlock = true;
+                    continue;
+                }
+                if (line.startsWith(")")) {
+                    inRequireBlock = false;
+                    inReplaceBlock = false;
+                    continue;
+                }
+                if (inRequireBlock) {
+                    String[] parts = line.split("\\s+");
+                    if (parts.length >= 2) {
+                        String path = parts[0];
+                        String version = parts[1];
+                        packages.put(path, version);
+                    }
+                    continue;
+                }
+                if (this.isInlineRequire(line)) {
+                    String[] parts = line.split("\\s+");
+                    String path = parts[1];
+                    String version = parts[2];
+                    packages.put(path, version);
+                    continue;
+                }
+                if (inReplaceBlock) {
+                    String[] parts = line.split("\\s+");
+                    if (parts.length == 5) {
+                        packages.remove(parts[0]);
+                        packages.put(parts[3], parts[4]);
+                    }
+                    continue;
+                }
+                if (this.isInlineReplace(line)) {
+                    String[] parts = line.split("\\s+");
+                    packages.remove(parts[1]);
+                    packages.put(parts[4], parts[5]);
+                    continue;
+                }
+            }
+            reader.close();
+        } catch (IOException e) {
+            throw new VulnerabilityException("Failed to read go.mod file", e);
+        }
+        return packages;
+    }
+
+    @Override
+    public boolean exists() {
+        return this.file.exists();
+    }
+    
+    private boolean isRequireBlock(String line) {
+        String[] parts = line.split("\\s+");
+        return line.startsWith("require(") || 
+                (line.startsWith("require") && parts.length == 2);
+    }
+
+    private boolean isInlineRequire(String line) {
+        String[] parts = line.split("\\s+");
+        return line.startsWith("require ") && parts.length == 3;
+    }
+
+    private boolean isReplaceBlock(String line) {
+        String[] parts = line.split("\\s+");
+        return line.startsWith("replace(") || 
+                (line.startsWith("replace") && parts.length == 2);
+    }
+
+    private boolean isInlineReplace(String line) {
+        String[] parts = line.split("\\s+");
+        return line.startsWith("replace ") && parts.length == 6;
+    }
+}

--- a/src/main/java/com/alvarium/annotators/vulnerability/PackageFileHandlerFactory.java
+++ b/src/main/java/com/alvarium/annotators/vulnerability/PackageFileHandlerFactory.java
@@ -18,7 +18,8 @@ public class PackageFileHandlerFactory {
     
     public PackageFileHandler getHandler(String dir) throws VulnerabilityException {
         final PackageFileHandler[] handlers = {
-            new MavenHandler(dir)
+            new MavenHandler(dir),
+            new GoModHandler(dir)
         };
 
         for (PackageFileHandler h : handlers) {

--- a/src/test/java/com/alvarium/annotators/vulnerability/GoModHandlerTest.java
+++ b/src/test/java/com/alvarium/annotators/vulnerability/GoModHandlerTest.java
@@ -1,0 +1,238 @@
+/*******************************************************************************
+ * Copyright 2023 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package com.alvarium.annotators.vulnerability;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+
+public class GoModHandlerTest {
+    @Rule
+    public TemporaryFolder dir = new TemporaryFolder();
+
+    @Test
+    public void testGetPackagesWtihRequireBlock() throws Exception {
+        File project = dir.newFolder("project");
+        File gomodFile = new File(project.toPath() + "/go.mod");
+
+        String artifactId1 = "pkg1/v1";
+        String version1 = "v1.0";
+        String artifactId2 = "pkg2/v2";
+        String version2 = "v2.0";
+        
+        StringBuilder goModContent = new StringBuilder();
+        goModContent.append("module github.com/edgexfoundry/edgex-go\n");
+        goModContent.append("\n");
+        goModContent.append("go 1.20\n");
+        goModContent.append("\n");
+        goModContent.append("require (\n");
+        goModContent.append(artifactId1 + " " + version1 +"\n");
+        goModContent.append(artifactId2 + " " + version2 +"\n");
+        goModContent.append(")");
+
+        Files.writeString(gomodFile.toPath(), goModContent.toString());
+
+        GoModHandler handler = new GoModHandler(project.getAbsolutePath());
+
+        assert handler.getFileName().equals(gomodFile.getName());
+
+        Map<String, String> packages = handler.getPackages();
+        
+        assert packages.keySet().size() == 2;
+        assert packages.get(artifactId1).equals(version1);
+        assert packages.get(artifactId2).equals(version2);
+    }
+
+    @Test
+    public void testGetPackagesWithoutRequireBlock() throws Exception {
+        File project = dir.newFolder("project");
+        File gomodFile = new File(project.toPath() + "/go.mod");
+
+        String artifactId1 = "pkg1/v1";
+        String version1 = "v1.0";
+        String artifactId2 = "pkg2/v2";
+        String version2 = "v2.0";
+
+        StringBuilder goModContent = new StringBuilder();
+        goModContent.append("module github.com/edgexfoundry/edgex-go\n");
+        goModContent.append("\n");
+        goModContent.append("go 1.20\n");
+        goModContent.append("\n");
+        goModContent.append("require " + artifactId1 + " " + version1 +"\n");
+        goModContent.append("require " + artifactId2 + " " + version2 +"\n");
+
+        Files.writeString(gomodFile.toPath(), goModContent.toString());
+
+        GoModHandler handler = new GoModHandler(project.getAbsolutePath());
+
+        assert handler.getFileName().equals(gomodFile.getName());
+
+        Map<String, String> packages = handler.getPackages();
+        
+        assert packages.keySet().size() == 2;
+        assert packages.get(artifactId1).equals(version1);
+        assert packages.get(artifactId2).equals(version2);
+    }
+
+    @Test
+    public void testGetPackagesWithMixedRequireLines() throws Exception {
+        File project = dir.newFolder("project");
+        File gomodFile = new File(project.toPath() + "/go.mod");
+
+        String artifactId1 = "pkg1/v1";
+        String version1 = "v1.0";
+        String artifactId2 = "pkg2/v2";
+        String version2 = "v2.0";
+        String artifactId3 = "pkg3/v3";
+        String version3 = "v3.0";
+        String artifactId4 = "pkg4/v4";
+        String version4 = "v4.0";
+
+
+
+        StringBuilder goModContent = new StringBuilder();
+        goModContent.append("module github.com/edgexfoundry/edgex-go\n");
+        goModContent.append("\n");
+        goModContent.append("go 1.20\n");
+        goModContent.append("\n");
+
+        goModContent.append("require " + artifactId1 + " " + version1 +"\n");
+        goModContent.append("exclude example.com/old/thing v1.2.3\n");
+        goModContent.append("require (\n");
+        goModContent.append(artifactId2 + " " + version2 +"\n");
+        goModContent.append(artifactId3 + " " + version3 +"\n");
+        goModContent.append(")\n");
+        goModContent.append("require " + artifactId4 + " " + version4 +"\n");
+        goModContent.append("retract [v1.9.0, v1.9.5]\n");
+
+        Files.writeString(gomodFile.toPath(), goModContent.toString());
+
+        GoModHandler handler = new GoModHandler(project.getAbsolutePath());
+
+        assert handler.getFileName().equals(gomodFile.getName());
+
+        Map<String, String> packages = handler.getPackages();
+        
+        assert packages.keySet().size() == 4;
+        assert packages.get(artifactId1).equals(version1);
+        assert packages.get(artifactId2).equals(version2);
+        assert packages.get(artifactId3).equals(version3);
+        assert packages.get(artifactId4).equals(version4);
+
+    }
+
+    @Test
+    public void testGetPackagesWithoutReplaceBlock() throws Exception {
+        File project = dir.newFolder("project");
+        File gomodFile = new File(project.toPath() + "/go.mod");
+
+        String artifactId1 = "pkg1/v1";
+        String version1 = "v1.0";
+        String artifactId2 = "pkg2/v2";
+        String version2 = "v2.0";
+        String artifactId3 = "pkg3/v3";
+        String version3 = "v3.0";
+        String artifactId4 = "pkg4/v4";
+        String version4 = "v4.0";
+        String artifactId5 = "pkg5/v5";
+        String version5 = "v5.0";
+
+
+        StringBuilder goModContent = new StringBuilder();
+        goModContent.append("module github.com/edgexfoundry/edgex-go\n");
+        goModContent.append("\n");
+        goModContent.append("go 1.20\n");
+        goModContent.append("\n");
+
+        goModContent.append("require " + artifactId1 + " " + version1 +"\n");
+        goModContent.append("exclude example.com/old/thing v1.2.3\n");
+        goModContent.append("require (\n");
+        goModContent.append(artifactId2 + " " + version2 +"\n");
+        goModContent.append(artifactId3 + " " + version3 +"\n");
+        goModContent.append(")\n");
+        goModContent.append("replace " + artifactId3 + " " + version3 + " => " + artifactId5 + " " + version5 +"\n");
+        goModContent.append("require " + artifactId4 + " " + version4 +"\n");
+        goModContent.append("retract [v1.9.0, v1.9.5]\n");
+
+        Files.writeString(gomodFile.toPath(), goModContent.toString());
+
+        GoModHandler handler = new GoModHandler(project.getAbsolutePath());
+
+        assert handler.getFileName().equals(gomodFile.getName());
+
+        Map<String, String> packages = handler.getPackages();
+        
+        assert packages.keySet().size() == 4;
+        assert packages.get(artifactId1).equals(version1);
+        assert packages.get(artifactId2).equals(version2);
+        assert packages.get(artifactId4).equals(version4);
+        assert packages.get(artifactId5).equals(version5);
+    }
+
+    @Test
+    public void testGetPackagesWithReplaceBlock() throws Exception {
+        File project = dir.newFolder("project");
+        File gomodFile = new File(project.toPath() + "/go.mod");
+
+        String artifactId1 = "pkg1/v1";
+        String version1 = "v1.0";
+        String artifactId2 = "pkg2/v2";
+        String version2 = "v2.0";
+        String artifactId3 = "pkg3/v3";
+        String version3 = "v3.0";
+        String artifactId4 = "pkg4/v4";
+        String version4 = "v4.0";
+        String artifactId5 = "pkg5/v5";
+        String version5 = "v5.0";
+
+
+        StringBuilder goModContent = new StringBuilder();
+        goModContent.append("module github.com/edgexfoundry/edgex-go\n");
+        goModContent.append("\n");
+        goModContent.append("go 1.20\n");
+        goModContent.append("\n");
+
+        goModContent.append("require " + artifactId1 + " " + version1 +"\n");
+        goModContent.append("exclude example.com/old/thing v1.2.3\n");
+        goModContent.append("require (\n");
+        goModContent.append(artifactId2 + " " + version2 +"\n");
+        goModContent.append(artifactId3 + " " + version3 +"\n");
+        goModContent.append(")\n");
+        goModContent.append("replace (\n");
+        goModContent.append(artifactId2 + " " + version2 + " => " + artifactId4 + " " + version4 +"\n");
+        goModContent.append(artifactId3 + " " + version3 + " => " + artifactId5 + " " + version5 +"\n");
+        goModContent.append(")\n");
+        goModContent.append("retract [v1.9.0, v1.9.5]\n");
+
+        Files.writeString(gomodFile.toPath(), goModContent.toString());
+
+        GoModHandler handler = new GoModHandler(project.getAbsolutePath());
+
+        assert handler.getFileName().equals(gomodFile.getName());
+
+        Map<String, String> packages = handler.getPackages();
+        
+        assert packages.keySet().size() == 3;
+        assert packages.get(artifactId1).equals(version1);
+        assert packages.get(artifactId4).equals(version4);
+        assert packages.get(artifactId5).equals(version5);
+    }
+
+}

--- a/src/test/java/com/alvarium/annotators/vulnerability/PackageFileHandlerFactoryTest.java
+++ b/src/test/java/com/alvarium/annotators/vulnerability/PackageFileHandlerFactoryTest.java
@@ -31,4 +31,12 @@ public class PackageFileHandlerFactoryTest {
         PackageFileHandler handler = factory.getHandler(pom.toPath().getParent().toString());
         assert handler instanceof MavenHandler;
     }
+
+    @Test
+    public void shouldReturnGoModHandler() throws Exception {
+        File gomod = dir.newFile("go.mod");
+        PackageFileHandlerFactory factory = new PackageFileHandlerFactory();
+        PackageFileHandler handler = factory.getHandler(gomod.toPath().getParent().toString());
+        assert handler instanceof GoModHandler;
+    }
 }


### PR DESCRIPTION
Fix #121

- Add GoModHandler that implements PackageHandler Interface
- Add the GoModHandler to the PackageFileHandlerFactory to be returned if a go.mod file exists.
- Add unit tests for GoModHandler and the factory.