### PR TITLE
Wrap getPackages() call in the try-catch block

### DIFF
--- a/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
@@ -61,7 +61,6 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
         final String key = super.deriveHash(hash, data);
 
         String dir = ctx.getProperty(AnnotationType.VULNERABILITY.name(), String.class);
-        Map<String, String> packages = getPackages(dir);
         
         List<String> vulnerabilities;
         boolean isSatisfied;
@@ -69,6 +68,7 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
         try{
             host = InetAddress.getLocalHost().getHostName();
 
+            Map<String, String> packages = getPackages(dir);
             vulnerabilities = retrievePackagesVulnerabilities(packages);
             isSatisfied = vulnerabilities.isEmpty();
         } catch (UnknownHostException | AnnotatorException e) {


### PR DESCRIPTION
FIX #122 
- Wrap the getPackages call in the try catch block in the VunlerabilityAnnotator to publish an unsatisfied annotation when exception is thrown during scanning package file