### PR TITLE
Refactor SourceCodeAnnotator hashing methodology to match that of external tools

### DIFF
--- a/src/test/java/com/alvarium/annotators/SourceCodeAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/SourceCodeAnnotatorTest.java
@@ -17,12 +17,7 @@ package com.alvarium.annotators;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -41,6 +36,7 @@ import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashProvider;
 import com.alvarium.hash.HashProviderFactory;
 import com.alvarium.hash.HashType;
+import com.alvarium.hash.HashTypeException;
 import com.alvarium.serializers.AnnotatorConfigConverter;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignType;
@@ -56,7 +52,7 @@ public class SourceCodeAnnotatorTest {
         public TemporaryFolder dir = new TemporaryFolder();
 
         @Test
-        public void executeShouldReturnAnnotation() throws AnnotatorException {
+        public void executeShouldReturnAnnotation() throws AnnotatorException, IOException, HashTypeException {
                 AnnotatorFactory factory = new AnnotatorFactory();
                 KeyInfo privateKey = new KeyInfo(
                                 "./src/test/java/com/alvarium/annotators/public.key",
@@ -82,25 +78,29 @@ public class SourceCodeAnnotatorTest {
                 Configurator.setRootLevel(Level.DEBUG);
                 Annotator annotator = factory.getAnnotator(annotatorInfo, config, logger);
 
-                // Generate dummy source code directory and 
-                // generate checksum for dummy source code
-                File sourceCodeDir;
-                File checksum; 
-                File f1;
-                try {
-                        sourceCodeDir = dir.newFolder("source-code");
-                        f1 = new File(sourceCodeDir.toPath().toString() + "/f1");
-                        checksum = dir.newFile("checksum");
-                } catch (IOException e) {
-                        throw new AnnotatorException("Could not create test file", e);
-                }
-                
-                generateAndWriteChecksum(sourceCodeDir, checksum.toPath(), config.getHash().getType());
-
+                final File sourceCodeDir = dir.newFolder("sourceCode");
+                final File f1 = new File(sourceCodeDir, "file1");
+                final File subDirectory = new File(sourceCodeDir, "sub");
+                final File f2 = new File(subDirectory, "file2");
+                subDirectory.mkdir();
+                f1.createNewFile();
+                f2.createNewFile();
+                Files.write(f1.toPath(), "foo".getBytes());
+                Files.write(f2.toPath(), "boo".getBytes());
+    
+                final File checksumFile = dir.newFile("checksum");
+    
+                final HashProvider hash = new HashProviderFactory().getProvider(config.getHash().getType());
+                String hashAndPath = hash.derive(Files.readAllBytes(f1.toPath())) + "  " + f1.toPath().toString() + "\n";
+                hashAndPath = hashAndPath + hash.derive(Files.readAllBytes(f2.toPath())) + "  " + f2.toPath().toString() + "\n";
+                final String checksum = hash.derive(hashAndPath.getBytes());
+    
+                Files.write(checksumFile.toPath(), checksum.getBytes());
+    
                 final SourceCodeAnnotatorProps props = 
                         new SourceCodeAnnotatorProps(
                                 sourceCodeDir.toPath().toString(), 
-                                checksum.toPath().toString()
+                                checksumFile.toPath().toString()
                 );
 
                 PropertyBag ctx = new ImmutablePropertyBag(
@@ -114,11 +114,7 @@ public class SourceCodeAnnotatorTest {
                 assert annotation.getIsSatisfied();
 
                 // tamper with existing file in source code
-                try {
-                        Files.write(f1.toPath(), "foo".getBytes()); 
-                } catch (IOException e) {
-                        throw new AnnotatorException("Could not write to test file", e);
-                }
+                Files.write(f1.toPath(), "tampered".getBytes()); 
                 
                 annotation = annotator.execute(ctx, data);
                 System.out.println(annotation.toJson());
@@ -126,42 +122,4 @@ public class SourceCodeAnnotatorTest {
                 assert !annotation.getIsSatisfied();
 
         }
-
-
-        /**
-         * Writes the checksum of a sourceCodeDir to a file located at checksumPath using the same
-         * hashing algorithm provided to the source annotator
-         * @param sourceCodeDir
-         * @param checksumPath
-         * @throws AnnotatorException
-         */
-        private void generateAndWriteChecksum(File sourceCodeDir, Path checksumPath, HashType hashType) throws AnnotatorException {
-                try {
-                        final HashProvider hash = new HashProviderFactory().getProvider(hashType);
-                        Optional<Exception> exception = Files.find(
-                                Paths.get(sourceCodeDir.toURI()), 
-                                Integer.MAX_VALUE, 
-                                (Path filePath, BasicFileAttributes fileAttr) -> !fileAttr.isDirectory()) 
-                                .sorted() 
-                                .flatMap((Path f) ->  {
-                                        try {
-                                                hash.update(Files.readAllBytes(f));
-                                                return null;
-                                        } catch (Exception e) {
-                                                return Stream.of(e);
-                                        }
-                                })
-                                .reduce((Exception exc1, Exception exc2) -> {
-                                        exc1.addSuppressed(exc2);
-                                        return exc1;
-                                });
-                        if (exception.isPresent()) {
-                                throw new AnnotatorException("Error reading files", exception.get());
-                        }
-                        Files.write(checksumPath, hash.getValue().getBytes());
-                } catch (Exception e) {
-                        throw new AnnotatorException("foo", e);
-                }
-        }
-
 }


### PR DESCRIPTION
Fix #124
- Refactored the checksum generation to match the following bash command:
```find "$PATH" -type f -exec md5sum {} + | LC_ALL=C sort | md5sum```
  - List all files recursively in the given directory.
  - Hash each file and concatenated its hash before it. Ex: ```ACBD18DB4CC2F85CEDEF654FCCC4A4D8  /path/file```
  - Sort the list of strings checksum path string using the "US" locale to ensure consistent sorting.
  - Hash the combined string to return the generated source code checksum.
  Combined String Ex:
```
ACBD18DB4CC2F85CEDEF654FCCC4A4D8  /path/file
AE3E83E2FAB3A7D8683D8EEFABD1E74D  /path/file2

```
  > The string always ends with a new line to match the output of the bash command.
  - Implemented the getAllFiles method to recursively list all files in the directory and its subdirectories.
  - Refactored the readAndHashFile method to compute the hash value of each file given a file path
  - Refactored SourceCodeAnnotator test to accommodate for the new methodology.