### PR TITLE
Update Annotation Schema to Include "Tag" and "Layer" Fields

### DIFF
--- a/src/main/java/com/alvarium/SdkInfo.java
+++ b/src/main/java/com/alvarium/SdkInfo.java
@@ -17,6 +17,7 @@ package com.alvarium;
 import java.io.Serializable;
 
 import com.alvarium.annotators.AnnotatorConfig;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.serializers.AnnotatorConfigConverter;
 import com.alvarium.serializers.StreamInfoConverter;
@@ -33,13 +34,15 @@ public class SdkInfo implements Serializable {
   private final HashInfo hash;
   private final SignatureInfo signature;
   private final StreamInfo stream;
+  private final LayerType layer;
 
   public SdkInfo(AnnotatorConfig[] annotators, HashInfo hash, SignatureInfo signature,
-      StreamInfo stream) {
+      StreamInfo stream, LayerType layer) {
     this.annotators = annotators;
     this.hash = hash;
     this.signature = signature;
     this.stream = stream;
+    this.layer = layer;
   }
 
   public AnnotatorConfig[] getAnnotators() {
@@ -56,6 +59,10 @@ public class SdkInfo implements Serializable {
 
   public StreamInfo getStream() {
     return this.stream;
+  }
+
+  public LayerType getLayer(){
+    return this.layer;
   }
 
   public String toJson() {

--- a/src/main/java/com/alvarium/annotators/AbstractAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/AbstractAnnotator.java
@@ -37,7 +37,6 @@ import com.alvarium.utils.Encoder;
 abstract class AbstractAnnotator {
 
   protected  Logger logger;
-  public static final String TAG_ENV_KEY = "TAG";
 
   AbstractAnnotator(Logger logger) {
     this.logger = logger;

--- a/src/main/java/com/alvarium/annotators/AbstractAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/AbstractAnnotator.java
@@ -37,6 +37,7 @@ import com.alvarium.utils.Encoder;
 abstract class AbstractAnnotator {
 
   protected  Logger logger;
+  public static final String TAG_ENV_KEY = "TAG";
 
   AbstractAnnotator(Logger logger) {
     this.logger = logger;

--- a/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.Logger;
 import com.alvarium.SdkInfo;
 import com.alvarium.annotators.sbom.SbomAnnotatorConfig;
 import com.alvarium.annotators.vulnerability.VulnerabilityAnnotatorConfig;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
 
@@ -26,31 +27,32 @@ public class AnnotatorFactory {
   public Annotator getAnnotator(AnnotatorConfig cfg, SdkInfo config, Logger logger) throws AnnotatorException {
     final HashType hash = config.getHash().getType();
     final SignatureInfo signature = config.getSignature();
+    final LayerType layer = config.getLayer();
     switch (cfg.getKind()) {
       case MOCK:
         try {
             MockAnnotatorConfig mockCfg = MockAnnotatorConfig.class.cast(cfg);
-            return new MockAnnotator(mockCfg, hash, signature);
+            return new MockAnnotator(mockCfg, hash, signature, layer);
         } catch(ClassCastException e) {
             throw new AnnotatorException("Invalid annotator config", e);
         }
       case TLS:
-        return new TlsAnnotator(hash, signature, logger);
+        return new TlsAnnotator(hash, signature, logger, layer);
       case PKI:
-        return new PkiAnnotator(hash, signature, logger);
+        return new PkiAnnotator(hash, signature, logger, layer);
       case PKIHttp:
-        return new PkiHttpAnnotator(hash, signature, logger);
+        return new PkiHttpAnnotator(hash, signature, logger, layer);
       case TPM:
-        return new TpmAnnotator(hash, signature, logger);
+        return new TpmAnnotator(hash, signature, logger, layer);
       case SourceCode:
-        return new SourceCodeAnnotator(hash, signature, logger);
+        return new SourceCodeAnnotator(hash, signature, logger, layer);
       case CHECKSUM:
-        return new ChecksumAnnotator(hash, signature, logger);
+        return new ChecksumAnnotator(hash, signature, logger, layer);
       case VULNERABILITY:
         VulnerabilityAnnotatorConfig vulnCfg = VulnerabilityAnnotatorConfig.class.cast(cfg);
-        return new VulnerabilityAnnotator(vulnCfg, hash, signature, logger);
+        return new VulnerabilityAnnotator(vulnCfg, hash, signature, logger, layer);
       case SOURCE:
-        return new SourceAnnotator(hash, signature, logger);
+        return new SourceAnnotator(hash, signature, logger, layer);
       case SBOM:
         final SbomAnnotatorConfig sbomCfg = SbomAnnotatorConfig.class.cast(cfg);
         return new SbomAnnotator(sbomCfg, hash, signature, logger);

--- a/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
+++ b/src/main/java/com/alvarium/annotators/AnnotatorFactory.java
@@ -55,7 +55,7 @@ public class AnnotatorFactory {
         return new SourceAnnotator(hash, signature, logger, layer);
       case SBOM:
         final SbomAnnotatorConfig sbomCfg = SbomAnnotatorConfig.class.cast(cfg);
-        return new SbomAnnotator(sbomCfg, hash, signature, logger);
+        return new SbomAnnotator(sbomCfg, hash, signature, logger, layer);
       default:
         throw new AnnotatorException("Annotator type is not supported");
     }

--- a/src/main/java/com/alvarium/annotators/ChecksumAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/ChecksumAnnotator.java
@@ -25,8 +25,8 @@ import java.time.Instant;
 import org.apache.logging.log4j.Logger;
 
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashProvider;
 import com.alvarium.hash.HashProviderFactory;
 import com.alvarium.hash.HashType;
@@ -39,14 +39,16 @@ public class ChecksumAnnotator extends AbstractAnnotator implements Annotator {
     final private HashType hash;
     final private SignatureInfo signature;
     private final AnnotationType kind;
+    private final LayerType layer;
 
     private HashProvider hashProvider;
 
-    protected ChecksumAnnotator(HashType hash, SignatureInfo signature, Logger logger) {
+    protected ChecksumAnnotator(HashType hash, SignatureInfo signature, Logger logger, LayerType layer) {
         super(logger);
         this.hash = hash;
         this.signature = signature;
         this.kind = AnnotationType.CHECKSUM;
+        this.layer = layer;
     }
     
     @Override
@@ -83,7 +85,7 @@ public class ChecksumAnnotator extends AbstractAnnotator implements Annotator {
             this.hash, 
             host,
             tag,
-            AnnotationLayer.CHECKSUM,
+            layer,
             this.kind, 
             null, 
             isSatisfied, 

--- a/src/main/java/com/alvarium/annotators/ChecksumAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/ChecksumAnnotator.java
@@ -56,7 +56,6 @@ public class ChecksumAnnotator extends AbstractAnnotator implements Annotator {
         
         this.initHashProvider(this.hash);
         final String key = this.hashProvider.derive(data);
-        final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
         final ChecksumAnnotatorProps props = ctx.getProperty(
             AnnotationType.CHECKSUM.name(), 
@@ -84,7 +83,6 @@ public class ChecksumAnnotator extends AbstractAnnotator implements Annotator {
             key, 
             this.hash, 
             host,
-            tag,
             layer,
             this.kind, 
             null, 

--- a/src/main/java/com/alvarium/annotators/ChecksumAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/ChecksumAnnotator.java
@@ -53,6 +53,7 @@ public class ChecksumAnnotator extends AbstractAnnotator implements Annotator {
         
         this.initHashProvider(this.hash);
         final String key = this.hashProvider.derive(data);
+        final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
         final ChecksumAnnotatorProps props = ctx.getProperty(
             AnnotationType.CHECKSUM.name(), 
@@ -79,7 +80,8 @@ public class ChecksumAnnotator extends AbstractAnnotator implements Annotator {
         final Annotation annotation = new Annotation(
             key, 
             this.hash, 
-            host, 
+            host,
+            tag,
             this.kind, 
             null, 
             isSatisfied, 

--- a/src/main/java/com/alvarium/annotators/ChecksumAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/ChecksumAnnotator.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import org.apache.logging.log4j.Logger;
 
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashProvider;
 import com.alvarium.hash.HashProviderFactory;
@@ -82,6 +83,7 @@ public class ChecksumAnnotator extends AbstractAnnotator implements Annotator {
             this.hash, 
             host,
             tag,
+            AnnotationLayer.CHECKSUM,
             this.kind, 
             null, 
             isSatisfied, 

--- a/src/main/java/com/alvarium/annotators/MockAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/MockAnnotator.java
@@ -47,9 +47,10 @@ class MockAnnotator implements Annotator {
     try {
       final String key = hashFactory.getProvider(hash).derive(data);
       final String host = InetAddress.getLocalHost().getHostName();
+      final String tag = System.getenv(AbstractAnnotator.TAG_ENV_KEY) == null ? "" : System.getenv(AbstractAnnotator.TAG_ENV_KEY);
       final String sig = signature.getPublicKey().getType().toString();
 
-      final Annotation annotation = new Annotation(key, hash, host, kind, sig, cfg.getShouldSatisfy(), Instant.now());
+      final Annotation annotation = new Annotation(key, hash, host, tag, kind, sig, cfg.getShouldSatisfy(), Instant.now());
       return annotation;
     } catch (HashTypeException e) {
       throw new AnnotatorException("failed to hash data", e);

--- a/src/main/java/com/alvarium/annotators/MockAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/MockAnnotator.java
@@ -19,6 +19,7 @@ import java.net.UnknownHostException;
 import java.time.Instant;
 
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashProviderFactory;
 import com.alvarium.hash.HashType;
@@ -50,7 +51,7 @@ class MockAnnotator implements Annotator {
       final String tag = System.getenv(AbstractAnnotator.TAG_ENV_KEY) == null ? "" : System.getenv(AbstractAnnotator.TAG_ENV_KEY);
       final String sig = signature.getPublicKey().getType().toString();
 
-      final Annotation annotation = new Annotation(key, hash, host, tag, kind, sig, cfg.getShouldSatisfy(), Instant.now());
+      final Annotation annotation = new Annotation(key, hash, host, tag, AnnotationLayer.MOCK, kind, sig, cfg.getShouldSatisfy(), Instant.now());
       return annotation;
     } catch (HashTypeException e) {
       throw new AnnotatorException("failed to hash data", e);

--- a/src/main/java/com/alvarium/annotators/MockAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/MockAnnotator.java
@@ -19,8 +19,8 @@ import java.net.UnknownHostException;
 import java.time.Instant;
 
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashProviderFactory;
 import com.alvarium.hash.HashType;
 import com.alvarium.hash.HashTypeException;
@@ -35,12 +35,14 @@ class MockAnnotator implements Annotator {
   private final HashType hash;
   private final AnnotationType kind;
   private final SignatureInfo signature;
+  private final LayerType layer;
 
-  protected MockAnnotator(MockAnnotatorConfig cfg, HashType hash, SignatureInfo signature) {
+  protected MockAnnotator(MockAnnotatorConfig cfg, HashType hash, SignatureInfo signature, LayerType layer) {
     this.cfg = cfg;
     this.hash = hash;
     this.kind = AnnotationType.MOCK;
     this.signature = signature;
+    this.layer = layer;
   }
 
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
@@ -51,7 +53,7 @@ class MockAnnotator implements Annotator {
       final String tag = System.getenv(AbstractAnnotator.TAG_ENV_KEY) == null ? "" : System.getenv(AbstractAnnotator.TAG_ENV_KEY);
       final String sig = signature.getPublicKey().getType().toString();
 
-      final Annotation annotation = new Annotation(key, hash, host, tag, AnnotationLayer.MOCK, kind, sig, cfg.getShouldSatisfy(), Instant.now());
+      final Annotation annotation = new Annotation(key, hash, host, tag, layer, kind, sig, cfg.getShouldSatisfy(), Instant.now());
       return annotation;
     } catch (HashTypeException e) {
       throw new AnnotatorException("failed to hash data", e);

--- a/src/main/java/com/alvarium/annotators/MockAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/MockAnnotator.java
@@ -50,10 +50,9 @@ class MockAnnotator implements Annotator {
     try {
       final String key = hashFactory.getProvider(hash).derive(data);
       final String host = InetAddress.getLocalHost().getHostName();
-      final String tag = System.getenv(AbstractAnnotator.TAG_ENV_KEY) == null ? "" : System.getenv(AbstractAnnotator.TAG_ENV_KEY);
       final String sig = signature.getPublicKey().getType().toString();
 
-      final Annotation annotation = new Annotation(key, hash, host, tag, layer, kind, sig, cfg.getShouldSatisfy(), Instant.now());
+      final Annotation annotation = new Annotation(key, hash, host, layer, kind, sig, cfg.getShouldSatisfy(), Instant.now());
       return annotation;
     } catch (HashTypeException e) {
       throw new AnnotatorException("failed to hash data", e);

--- a/src/main/java/com/alvarium/annotators/PkiAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/PkiAnnotator.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import org.apache.logging.log4j.Logger;
 
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
@@ -60,6 +61,7 @@ class PkiAnnotator extends AbstractPkiAnnotator implements Annotator {
         hash, 
         host, 
         tag,
+        AnnotationLayer.PKI,
         kind, 
         null, 
         isSatisfied, 

--- a/src/main/java/com/alvarium/annotators/PkiAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/PkiAnnotator.java
@@ -43,7 +43,6 @@ class PkiAnnotator extends AbstractPkiAnnotator implements Annotator {
 
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
     final String key = super.deriveHash(hash, data);
-    final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
     final Signable signable = Signable.fromJson(new String(data));
 
@@ -62,7 +61,6 @@ class PkiAnnotator extends AbstractPkiAnnotator implements Annotator {
         key, 
         hash, 
         host, 
-        tag,
         layer,
         kind, 
         null, 

--- a/src/main/java/com/alvarium/annotators/PkiAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/PkiAnnotator.java
@@ -21,8 +21,8 @@ import java.time.Instant;
 import org.apache.logging.log4j.Logger;
 
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.PropertyBag;
@@ -31,12 +31,14 @@ class PkiAnnotator extends AbstractPkiAnnotator implements Annotator {
   private final HashType hash;
   private final SignatureInfo signature;
   private final AnnotationType kind;
+  private final LayerType layer;
 
-  protected PkiAnnotator(HashType hash, SignatureInfo signature, Logger logger) {
+  protected PkiAnnotator(HashType hash, SignatureInfo signature, Logger logger, LayerType layer) {
     super(logger);
     this.hash = hash;
     this.signature = signature;
     this.kind = AnnotationType.PKI;
+    this.layer = layer;
   }
 
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
@@ -61,7 +63,7 @@ class PkiAnnotator extends AbstractPkiAnnotator implements Annotator {
         hash, 
         host, 
         tag,
-        AnnotationLayer.PKI,
+        layer,
         kind, 
         null, 
         isSatisfied, 

--- a/src/main/java/com/alvarium/annotators/PkiAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/PkiAnnotator.java
@@ -40,6 +40,7 @@ class PkiAnnotator extends AbstractPkiAnnotator implements Annotator {
 
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
     final String key = super.deriveHash(hash, data);
+    final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
     final Signable signable = Signable.fromJson(new String(data));
 
@@ -58,6 +59,7 @@ class PkiAnnotator extends AbstractPkiAnnotator implements Annotator {
         key, 
         hash, 
         host, 
+        tag,
         kind, 
         null, 
         isSatisfied, 

--- a/src/main/java/com/alvarium/annotators/PkiHttpAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/PkiHttpAnnotator.java
@@ -52,7 +52,6 @@ class PkiHttpAnnotator extends AbstractPkiAnnotator implements Annotator {
 
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
     final String key = super.deriveHash(hash, data);
-    final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
     HttpUriRequest request;
     try {
@@ -100,7 +99,6 @@ class PkiHttpAnnotator extends AbstractPkiAnnotator implements Annotator {
         key,
         hash,
         host,
-        tag,
         layer,
         kind,
         null,

--- a/src/main/java/com/alvarium/annotators/PkiHttpAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/PkiHttpAnnotator.java
@@ -49,6 +49,7 @@ class PkiHttpAnnotator extends AbstractPkiAnnotator implements Annotator {
 
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
     final String key = super.deriveHash(hash, data);
+    final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
     HttpUriRequest request;
     try {
@@ -96,6 +97,7 @@ class PkiHttpAnnotator extends AbstractPkiAnnotator implements Annotator {
         key,
         hash,
         host,
+        tag,
         kind,
         null,
         isSatisfied,

--- a/src/main/java/com/alvarium/annotators/PkiHttpAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/PkiHttpAnnotator.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import com.alvarium.annotators.http.ParseResult;
 import com.alvarium.annotators.http.ParseResultException;
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.KeyInfo;
@@ -98,6 +99,7 @@ class PkiHttpAnnotator extends AbstractPkiAnnotator implements Annotator {
         hash,
         host,
         tag,
+        AnnotationLayer.PKIHttp,
         kind,
         null,
         isSatisfied,

--- a/src/main/java/com/alvarium/annotators/PkiHttpAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/PkiHttpAnnotator.java
@@ -25,8 +25,8 @@ import java.nio.file.Path;
 import com.alvarium.annotators.http.ParseResult;
 import com.alvarium.annotators.http.ParseResultException;
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.KeyInfo;
 import com.alvarium.sign.SignatureInfo;
@@ -40,12 +40,14 @@ class PkiHttpAnnotator extends AbstractPkiAnnotator implements Annotator {
   private final HashType hash;
   private final SignatureInfo signature;
   private final AnnotationType kind;
+  private final LayerType layer;
 
-  protected PkiHttpAnnotator(HashType hash, SignatureInfo signature, Logger logger) {
+  protected PkiHttpAnnotator(HashType hash, SignatureInfo signature, Logger logger, LayerType layer) {
     super(logger);
     this.hash = hash;
     this.signature = signature;
     this.kind = AnnotationType.PKIHttp;
+    this.layer = layer;
   }
 
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
@@ -99,7 +101,7 @@ class PkiHttpAnnotator extends AbstractPkiAnnotator implements Annotator {
         hash,
         host,
         tag,
-        AnnotationLayer.PKIHttp,
+        layer,
         kind,
         null,
         isSatisfied,

--- a/src/main/java/com/alvarium/annotators/SbomAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/SbomAnnotator.java
@@ -25,6 +25,7 @@ import com.alvarium.annotators.sbom.SbomProvider;
 import com.alvarium.annotators.sbom.SbomProviderFactory;
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.PropertyBag;
@@ -35,13 +36,15 @@ public class SbomAnnotator extends AbstractAnnotator implements Annotator {
   final HashType hash;
   final SignatureInfo signature;
   final AnnotationType kind;
+  final LayerType layer;
 
-  protected SbomAnnotator(SbomAnnotatorConfig cfg, HashType hash, SignatureInfo signature, Logger logger) {
+  protected SbomAnnotator(SbomAnnotatorConfig cfg, HashType hash, SignatureInfo signature, Logger logger, LayerType layer) {
     super(logger);
     this.cfg = cfg;
     this.hash = hash;
     this.signature = signature;
     this.kind = AnnotationType.SBOM;
+    this.layer = layer;
   }
   
   @Override 
@@ -73,6 +76,7 @@ public class SbomAnnotator extends AbstractAnnotator implements Annotator {
         key, 
         hash, 
         host, 
+        layer,
         kind, 
         null, 
         isSatisfied, 

--- a/src/main/java/com/alvarium/annotators/SourceAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/SourceAnnotator.java
@@ -21,8 +21,8 @@ import java.time.Instant;
 import org.apache.logging.log4j.Logger;
 
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.PropertyBag;
@@ -35,12 +35,14 @@ class SourceAnnotator extends AbstractAnnotator implements Annotator {
   private final HashType hash;
   private final AnnotationType kind;
   private final SignatureInfo signatureInfo;
+  private final LayerType layer;
   
-  protected SourceAnnotator(HashType hash, SignatureInfo signatureInfo, Logger logger) {
+  protected SourceAnnotator(HashType hash, SignatureInfo signatureInfo, Logger logger, LayerType layer) {
     super(logger);
     this.hash = hash;
     this.kind = AnnotationType.SOURCE;
     this.signatureInfo = signatureInfo;
+    this.layer = layer;
   }  
 
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
@@ -61,7 +63,7 @@ class SourceAnnotator extends AbstractAnnotator implements Annotator {
     isSatisfied = true;
 
     // create an annotation without signature
-    final Annotation annotation = new Annotation(key, this.hash, host, tag, AnnotationLayer.SOURCE, this.kind, null, isSatisfied,
+    final Annotation annotation = new Annotation(key, this.hash, host, tag, layer, this.kind, null, isSatisfied,
         Instant.now());
     
     final String signature = super.signAnnotation(signatureInfo.getPrivateKey(), annotation);

--- a/src/main/java/com/alvarium/annotators/SourceAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/SourceAnnotator.java
@@ -48,7 +48,6 @@ class SourceAnnotator extends AbstractAnnotator implements Annotator {
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
     // hash incoming data
     final String key = super.deriveHash(this.hash, data);
-    final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
     // get hostname if available
     String host = "";
@@ -63,7 +62,7 @@ class SourceAnnotator extends AbstractAnnotator implements Annotator {
     isSatisfied = true;
 
     // create an annotation without signature
-    final Annotation annotation = new Annotation(key, this.hash, host, tag, layer, this.kind, null, isSatisfied,
+    final Annotation annotation = new Annotation(key, this.hash, host, layer, this.kind, null, isSatisfied,
         Instant.now());
     
     final String signature = super.signAnnotation(signatureInfo.getPrivateKey(), annotation);

--- a/src/main/java/com/alvarium/annotators/SourceAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/SourceAnnotator.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import org.apache.logging.log4j.Logger;
 
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
@@ -60,7 +61,7 @@ class SourceAnnotator extends AbstractAnnotator implements Annotator {
     isSatisfied = true;
 
     // create an annotation without signature
-    final Annotation annotation = new Annotation(key, this.hash, host, tag, this.kind, null, isSatisfied,
+    final Annotation annotation = new Annotation(key, this.hash, host, tag, AnnotationLayer.SOURCE, this.kind, null, isSatisfied,
         Instant.now());
     
     final String signature = super.signAnnotation(signatureInfo.getPrivateKey(), annotation);

--- a/src/main/java/com/alvarium/annotators/SourceAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/SourceAnnotator.java
@@ -45,6 +45,7 @@ class SourceAnnotator extends AbstractAnnotator implements Annotator {
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
     // hash incoming data
     final String key = super.deriveHash(this.hash, data);
+    final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
     // get hostname if available
     String host = "";
@@ -59,7 +60,7 @@ class SourceAnnotator extends AbstractAnnotator implements Annotator {
     isSatisfied = true;
 
     // create an annotation without signature
-    final Annotation annotation = new Annotation(key, this.hash, host, this.kind, null, isSatisfied,
+    final Annotation annotation = new Annotation(key, this.hash, host, tag, this.kind, null, isSatisfied,
         Instant.now());
     
     final String signature = super.signAnnotation(signatureInfo.getPrivateKey(), annotation);

--- a/src/main/java/com/alvarium/annotators/SourceCodeAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/SourceCodeAnnotator.java
@@ -64,7 +64,6 @@ class SourceCodeAnnotator extends AbstractAnnotator implements Annotator {
     public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
         this.initHashProvider(this.hash);
         final String key = this.hashProvider.derive(data);
-        final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
         final SourceCodeAnnotatorProps props = ctx.getProperty(
             AnnotationType.SourceCode.name(),
@@ -87,7 +86,6 @@ class SourceCodeAnnotator extends AbstractAnnotator implements Annotator {
                 key,
                 hash,
                 host,
-                tag,
                 layer,
                 kind,
                 null,

--- a/src/main/java/com/alvarium/annotators/SourceCodeAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/SourceCodeAnnotator.java
@@ -61,6 +61,7 @@ class SourceCodeAnnotator extends AbstractAnnotator implements Annotator {
     public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
         this.initHashProvider(this.hash);
         final String key = this.hashProvider.derive(data);
+        final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
         final SourceCodeAnnotatorProps props = ctx.getProperty(
             AnnotationType.SourceCode.name(),
@@ -83,6 +84,7 @@ class SourceCodeAnnotator extends AbstractAnnotator implements Annotator {
                 key,
                 hash,
                 host,
+                tag,
                 kind,
                 null,
                 isSatisfied,

--- a/src/main/java/com/alvarium/annotators/SourceCodeAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/SourceCodeAnnotator.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import org.apache.logging.log4j.Logger;
 
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashProvider;
 import com.alvarium.hash.HashProviderFactory;
@@ -85,6 +86,7 @@ class SourceCodeAnnotator extends AbstractAnnotator implements Annotator {
                 hash,
                 host,
                 tag,
+                AnnotationLayer.SourceCode,
                 kind,
                 null,
                 isSatisfied,

--- a/src/main/java/com/alvarium/annotators/SourceCodeAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/SourceCodeAnnotator.java
@@ -32,8 +32,8 @@ import java.util.Locale;
 import org.apache.logging.log4j.Logger;
 
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashProvider;
 import com.alvarium.hash.HashProviderFactory;
 import com.alvarium.hash.HashType;
@@ -46,14 +46,16 @@ class SourceCodeAnnotator extends AbstractAnnotator implements Annotator {
     private final HashType hash;
     private final AnnotationType kind;
     private final SignatureInfo signature;
+    private final LayerType layer;
 
     private HashProvider hashProvider;
 
-    protected SourceCodeAnnotator(HashType hash, SignatureInfo signature, Logger logger) {
+    protected SourceCodeAnnotator(HashType hash, SignatureInfo signature, Logger logger, LayerType layer) {
         super(logger);
         this.hash = hash;
         this.kind = AnnotationType.SourceCode;
         this.signature = signature;
+        this.layer = layer;
     }
 
     // File (git working directory) is to be passed in the ctx bag
@@ -86,7 +88,7 @@ class SourceCodeAnnotator extends AbstractAnnotator implements Annotator {
                 hash,
                 host,
                 tag,
-                AnnotationLayer.SourceCode,
+                layer,
                 kind,
                 null,
                 isSatisfied,

--- a/src/main/java/com/alvarium/annotators/TlsAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/TlsAnnotator.java
@@ -53,6 +53,7 @@ class TlsAnnotator extends AbstractAnnotator implements Annotator {
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
     // hash incoming data
     final String key = super.deriveHash(hash, data);
+    final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
     // get host name
     String host = "";
@@ -67,7 +68,7 @@ class TlsAnnotator extends AbstractAnnotator implements Annotator {
         SSLSocket.class));
 
     // create an annotation without signature
-    final Annotation annotation = new Annotation(key, hash, host, kind, null, isSatisfied, 
+    final Annotation annotation = new Annotation(key, hash, host, tag, kind, null, isSatisfied, 
         Instant.now());
 
     // sign annotation

--- a/src/main/java/com/alvarium/annotators/TlsAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/TlsAnnotator.java
@@ -23,8 +23,8 @@ import org.apache.logging.log4j.Logger;
 import java.time.Instant;
 
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.PropertyBag;
@@ -33,12 +33,14 @@ class TlsAnnotator extends AbstractAnnotator implements Annotator {
   private final HashType hash;
   private final AnnotationType kind;
   private final SignatureInfo signatureInfo;
+  private final LayerType layer;
   
-  protected TlsAnnotator(HashType hash, SignatureInfo signatureInfo, Logger logger) {
+  protected TlsAnnotator(HashType hash, SignatureInfo signatureInfo, Logger logger, LayerType layer) {
     super(logger);
     this.hash = hash;
     this.kind = AnnotationType.TLS;
     this.signatureInfo = signatureInfo;
+    this.layer = layer;
   }
 
   private Boolean verifyHandshake(SSLSocket socket) {
@@ -69,7 +71,7 @@ class TlsAnnotator extends AbstractAnnotator implements Annotator {
         SSLSocket.class));
 
     // create an annotation without signature
-    final Annotation annotation = new Annotation(key, hash, host, tag, AnnotationLayer.TLS, kind, null, isSatisfied, 
+    final Annotation annotation = new Annotation(key, hash, host, tag, layer, kind, null, isSatisfied, 
         Instant.now());
 
     // sign annotation

--- a/src/main/java/com/alvarium/annotators/TlsAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/TlsAnnotator.java
@@ -56,7 +56,6 @@ class TlsAnnotator extends AbstractAnnotator implements Annotator {
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
     // hash incoming data
     final String key = super.deriveHash(hash, data);
-    final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
     // get host name
     String host = "";
@@ -71,7 +70,7 @@ class TlsAnnotator extends AbstractAnnotator implements Annotator {
         SSLSocket.class));
 
     // create an annotation without signature
-    final Annotation annotation = new Annotation(key, hash, host, tag, layer, kind, null, isSatisfied, 
+    final Annotation annotation = new Annotation(key, hash, host, layer, kind, null, isSatisfied, 
         Instant.now());
 
     // sign annotation

--- a/src/main/java/com/alvarium/annotators/TlsAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/TlsAnnotator.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import java.time.Instant;
 
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
@@ -68,7 +69,7 @@ class TlsAnnotator extends AbstractAnnotator implements Annotator {
         SSLSocket.class));
 
     // create an annotation without signature
-    final Annotation annotation = new Annotation(key, hash, host, tag, kind, null, isSatisfied, 
+    final Annotation annotation = new Annotation(key, hash, host, tag, AnnotationLayer.TLS, kind, null, isSatisfied, 
         Instant.now());
 
     // sign annotation

--- a/src/main/java/com/alvarium/annotators/TpmAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/TpmAnnotator.java
@@ -50,7 +50,6 @@ class TpmAnnotator extends AbstractAnnotator implements Annotator {
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
     
     final String key = super.deriveHash(hash, data);
-    final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
     String host = "";
     boolean isSatisfied;
@@ -69,7 +68,6 @@ class TpmAnnotator extends AbstractAnnotator implements Annotator {
           key,
           hash,
           host,
-          tag,
           layer,
           kind,
           null,

--- a/src/main/java/com/alvarium/annotators/TpmAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/TpmAnnotator.java
@@ -25,8 +25,8 @@ import java.time.Instant;
 import org.apache.logging.log4j.Logger;
 
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.PropertyBag;
@@ -35,14 +35,16 @@ class TpmAnnotator extends AbstractAnnotator implements Annotator {
   private final HashType hash;
   private final AnnotationType kind;
   private final SignatureInfo signature;
+  private final LayerType layer;
   private final String directTpmPath = "/dev/tpm0";
   private final String tpmKernelManagedPath = "/dev/tpmrm0";
 
-  protected TpmAnnotator(HashType hash, SignatureInfo signature, Logger logger) {
+  protected TpmAnnotator(HashType hash, SignatureInfo signature, Logger logger, LayerType layer) {
     super(logger);
     this.hash = hash;
     this.signature = signature;
     this.kind = AnnotationType.TPM;
+    this.layer = layer;
   }
 
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
@@ -68,7 +70,7 @@ class TpmAnnotator extends AbstractAnnotator implements Annotator {
           hash,
           host,
           tag,
-          AnnotationLayer.TPM,
+          layer,
           kind,
           null,
           isSatisfied,

--- a/src/main/java/com/alvarium/annotators/TpmAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/TpmAnnotator.java
@@ -47,6 +47,7 @@ class TpmAnnotator extends AbstractAnnotator implements Annotator {
   public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
     
     final String key = super.deriveHash(hash, data);
+    final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
     String host = "";
     boolean isSatisfied;
@@ -65,6 +66,7 @@ class TpmAnnotator extends AbstractAnnotator implements Annotator {
           key,
           hash,
           host,
+          tag,
           kind,
           null,
           isSatisfied,

--- a/src/main/java/com/alvarium/annotators/TpmAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/TpmAnnotator.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import org.apache.logging.log4j.Logger;
 
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
@@ -67,6 +68,7 @@ class TpmAnnotator extends AbstractAnnotator implements Annotator {
           hash,
           host,
           tag,
+          AnnotationLayer.TPM,
           kind,
           null,
           isSatisfied,

--- a/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
@@ -59,6 +59,7 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
     @Override
     public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
         final String key = super.deriveHash(hash, data);
+        final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
         String dir = ctx.getProperty(AnnotationType.VULNERABILITY.name(), String.class);
         
@@ -80,6 +81,7 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
             key, 
             this.hash, 
             host, 
+            tag,
             this.kind, 
             null, 
             isSatisfied, 

--- a/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
@@ -28,8 +28,8 @@ import com.alvarium.annotators.vulnerability.VulnerabilityApiHandler;
 import com.alvarium.annotators.vulnerability.VulnerabilityApiHandlerFactory;
 import com.alvarium.annotators.vulnerability.VulnerabilityException;
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
 import com.alvarium.utils.PropertyBag;
@@ -41,6 +41,7 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
     final HashType hash;
     final SignatureInfo sign;
     final AnnotationType kind;
+    final LayerType layer;
 
     private PackageFileHandler packageHandler;
 
@@ -48,13 +49,15 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
         VulnerabilityAnnotatorConfig cfg, 
         HashType hash, 
         SignatureInfo signature,
-        Logger logger
+        Logger logger,
+        LayerType layer
     ) {
         super(logger);
         this.cfg = cfg;
         this.hash = hash;
         this.sign = signature;
         this.kind = AnnotationType.VULNERABILITY;
+        this.layer = layer;
     }
 
     @Override
@@ -83,7 +86,7 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
             this.hash, 
             host, 
             tag,
-            AnnotationLayer.VULNERABILITY,
+            layer,
             this.kind, 
             null, 
             isSatisfied, 

--- a/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
@@ -28,6 +28,7 @@ import com.alvarium.annotators.vulnerability.VulnerabilityApiHandler;
 import com.alvarium.annotators.vulnerability.VulnerabilityApiHandlerFactory;
 import com.alvarium.annotators.vulnerability.VulnerabilityException;
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
 import com.alvarium.sign.SignatureInfo;
@@ -82,6 +83,7 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
             this.hash, 
             host, 
             tag,
+            AnnotationLayer.VULNERABILITY,
             this.kind, 
             null, 
             isSatisfied, 

--- a/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
+++ b/src/main/java/com/alvarium/annotators/VulnerabilityAnnotator.java
@@ -63,7 +63,6 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
     @Override
     public Annotation execute(PropertyBag ctx, byte[] data) throws AnnotatorException {
         final String key = super.deriveHash(hash, data);
-        final String tag = System.getenv(TAG_ENV_KEY) == null ? "" : System.getenv(TAG_ENV_KEY);
 
         String dir = ctx.getProperty(AnnotationType.VULNERABILITY.name(), String.class);
         
@@ -85,7 +84,6 @@ public class VulnerabilityAnnotator extends AbstractAnnotator implements Annotat
             key, 
             this.hash, 
             host, 
-            tag,
             layer,
             this.kind, 
             null, 

--- a/src/main/java/com/alvarium/contracts/Annotation.java
+++ b/src/main/java/com/alvarium/contracts/Annotation.java
@@ -35,12 +35,13 @@ public class Annotation implements Serializable {
   private final HashType hash;
   private final String host;
   private final String tag;
+  private final AnnotationLayer layer;
   private final AnnotationType kind;
   private String signature;
   private final Boolean isSatisfied;
   private final Instant timestamp;
 
-  public Annotation(String key, HashType hash, String host, String tag, AnnotationType kind, String signature,
+  public Annotation(String key, HashType hash, String host, String tag, AnnotationLayer layer, AnnotationType kind, String signature,
       Boolean isSatisfied, Instant timestamp) {
     ULID ulid = new ULID();
     this.id = ulid.nextULID(); 
@@ -48,6 +49,7 @@ public class Annotation implements Serializable {
     this.hash = hash;
     this.host = host;
     this.tag = tag;
+    this.layer = layer;
     this.kind = kind;
     this.signature = signature;
     this.isSatisfied = isSatisfied;
@@ -80,6 +82,10 @@ public class Annotation implements Serializable {
 
     public String getTag() {
       return this.tag;
+    }
+
+    public AnnotationLayer getLayer() {
+      return this.layer;
     }
 
     public AnnotationType getKind() {

--- a/src/main/java/com/alvarium/contracts/Annotation.java
+++ b/src/main/java/com/alvarium/contracts/Annotation.java
@@ -35,13 +35,13 @@ public class Annotation implements Serializable {
   private final HashType hash;
   private final String host;
   private final String tag;
-  private final AnnotationLayer layer;
+  private final LayerType layer;
   private final AnnotationType kind;
   private String signature;
   private final Boolean isSatisfied;
   private final Instant timestamp;
 
-  public Annotation(String key, HashType hash, String host, String tag, AnnotationLayer layer, AnnotationType kind, String signature,
+  public Annotation(String key, HashType hash, String host, String tag, LayerType layer, AnnotationType kind, String signature,
       Boolean isSatisfied, Instant timestamp) {
     ULID ulid = new ULID();
     this.id = ulid.nextULID(); 
@@ -84,7 +84,7 @@ public class Annotation implements Serializable {
       return this.tag;
     }
 
-    public AnnotationLayer getLayer() {
+    public LayerType getLayer() {
       return this.layer;
     }
 

--- a/src/main/java/com/alvarium/contracts/Annotation.java
+++ b/src/main/java/com/alvarium/contracts/Annotation.java
@@ -34,18 +34,20 @@ public class Annotation implements Serializable {
   private final String key;
   private final HashType hash;
   private final String host;
+  private final String tag;
   private final AnnotationType kind;
   private String signature;
   private final Boolean isSatisfied;
   private final Instant timestamp;
 
-  public Annotation(String key, HashType hash, String host, AnnotationType kind, String signature,
+  public Annotation(String key, HashType hash, String host, String tag, AnnotationType kind, String signature,
       Boolean isSatisfied, Instant timestamp) {
     ULID ulid = new ULID();
     this.id = ulid.nextULID(); 
     this.key = key;
     this.hash = hash;
     this.host = host;
+    this.tag = tag;
     this.kind = kind;
     this.signature = signature;
     this.isSatisfied = isSatisfied;
@@ -74,6 +76,10 @@ public class Annotation implements Serializable {
     
     public String getHost() {
       return this.host;
+    }
+
+    public String getTag() {
+      return this.tag;
     }
 
     public AnnotationType getKind() {

--- a/src/main/java/com/alvarium/contracts/AnnotationLayer.java
+++ b/src/main/java/com/alvarium/contracts/AnnotationLayer.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright 2024 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.alvarium.contracts;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum AnnotationLayer {
+    @SerializedName("app") TPM, MOCK, TLS, PKI, PKIHttp, SOURCE,
+    @SerializedName("cicd") SourceCode, CHECKSUM, VULNERABILITY
+}
+

--- a/src/main/java/com/alvarium/contracts/LayerType.java
+++ b/src/main/java/com/alvarium/contracts/LayerType.java
@@ -15,8 +15,14 @@ package com.alvarium.contracts;
 
 import com.google.gson.annotations.SerializedName;
 
-public enum AnnotationLayer {
-    @SerializedName("app") TPM, MOCK, TLS, PKI, PKIHttp, SOURCE,
-    @SerializedName("cicd") SourceCode, CHECKSUM, VULNERABILITY
+public enum LayerType {
+    @SerializedName("app") 
+    Application,
+    @SerializedName("cicd") 
+    CiCd,
+    @SerializedName("os") 
+    Os,
+    @SerializedName("host") 
+    Host;
 }
 

--- a/src/test/java/com/alvarium/PublishWrapperTest.java
+++ b/src/test/java/com/alvarium/PublishWrapperTest.java
@@ -47,7 +47,6 @@ public class PublishWrapperTest {
       "key", 
       HashType.MD5Hash, 
       "host", 
-      "tag",
       LayerType.Application,
       AnnotationType.TPM, 
       "signature", 

--- a/src/test/java/com/alvarium/PublishWrapperTest.java
+++ b/src/test/java/com/alvarium/PublishWrapperTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationList;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.hash.HashType;
@@ -47,6 +48,7 @@ public class PublishWrapperTest {
       HashType.MD5Hash, 
       "host", 
       "tag",
+      AnnotationLayer.TPM,
       AnnotationType.TPM, 
       "signature", 
       true, 

--- a/src/test/java/com/alvarium/PublishWrapperTest.java
+++ b/src/test/java/com/alvarium/PublishWrapperTest.java
@@ -46,6 +46,7 @@ public class PublishWrapperTest {
       "key", 
       HashType.MD5Hash, 
       "host", 
+      "tag",
       AnnotationType.TPM, 
       "signature", 
       true, 

--- a/src/test/java/com/alvarium/PublishWrapperTest.java
+++ b/src/test/java/com/alvarium/PublishWrapperTest.java
@@ -20,9 +20,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.contracts.AnnotationList;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashType;
 
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class PublishWrapperTest {
       HashType.MD5Hash, 
       "host", 
       "tag",
-      AnnotationLayer.TPM,
+      LayerType.Application,
       AnnotationType.TPM, 
       "signature", 
       true, 

--- a/src/test/java/com/alvarium/annotators/AnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/AnnotatorTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 
 public class AnnotatorTest {
 
-
   @Test
   public void mockAnnotatorShouldReturnSatisfiedAnnotation() throws AnnotatorException {
     final KeyInfo keyInfo = new KeyInfo("path", SignType.none);
@@ -93,4 +92,35 @@ public class AnnotatorTest {
     assert satisfiedAnnotation.getIsSatisfied();
     assert !unsatisfiedAnnotation.getIsSatisfied();
   }  
+
+  @Test
+  public void mockAnnotatorShouldReturnTag() throws AnnotatorException {
+    final KeyInfo keyInfo = new KeyInfo("path", SignType.none);
+    final SignatureInfo signature = new SignatureInfo(keyInfo, keyInfo);
+    final HashInfo noHash = new HashInfo(HashType.NoHash);
+
+    final Gson gson = new GsonBuilder()
+      .registerTypeAdapter(AnnotatorConfig.class, new AnnotatorConfigConverter())
+      .create();
+
+    final String mockConfig = "{\"kind\": \"mock\"}";
+
+    final AnnotatorConfig annotatorInfo = gson.fromJson(mockConfig, AnnotatorConfig.class);
+
+    final AnnotatorConfig[] annotators = {annotatorInfo};
+    final SdkInfo noHashConfig = new SdkInfo(annotators, noHash, signature, null);
+
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
+
+    final AnnotatorFactory factory = new AnnotatorFactory();
+    final Annotator noHashAnnotator = factory.getAnnotator(annotatorInfo, noHashConfig, logger);
+
+    final byte[] data = "test data".getBytes();
+    final PropertyBag ctx = new ImmutablePropertyBag(new HashMap<>());
+
+    final Annotation noHashAnnotation = noHashAnnotator.execute(ctx, data);
+
+    assert "".equals(noHashAnnotation.getTag());
+  }
 }

--- a/src/test/java/com/alvarium/annotators/AnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/AnnotatorTest.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.AnnotationLayer;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.serializers.AnnotatorConfigConverter;
@@ -122,5 +123,36 @@ public class AnnotatorTest {
     final Annotation noHashAnnotation = noHashAnnotator.execute(ctx, data);
 
     assert "".equals(noHashAnnotation.getTag());
+  }
+
+  @Test
+  public void mockAnnotatorShouldReturnLayer() throws AnnotatorException {
+    final KeyInfo keyInfo = new KeyInfo("path", SignType.none);
+    final SignatureInfo signature = new SignatureInfo(keyInfo, keyInfo);
+    final HashInfo noHash = new HashInfo(HashType.NoHash);
+
+    final Gson gson = new GsonBuilder()
+      .registerTypeAdapter(AnnotatorConfig.class, new AnnotatorConfigConverter())
+      .create();
+
+    final String mockConfig = "{\"kind\": \"mock\"}";
+
+    final AnnotatorConfig annotatorInfo = gson.fromJson(mockConfig, AnnotatorConfig.class);
+
+    final AnnotatorConfig[] annotators = {annotatorInfo};
+    final SdkInfo noHashConfig = new SdkInfo(annotators, noHash, signature, null);
+
+    final Logger logger = LogManager.getRootLogger();
+    Configurator.setRootLevel(Level.DEBUG);
+
+    final AnnotatorFactory factory = new AnnotatorFactory();
+    final Annotator noHashAnnotator = factory.getAnnotator(annotatorInfo, noHashConfig, logger);
+
+    final byte[] data = "test data".getBytes();
+    final PropertyBag ctx = new ImmutablePropertyBag(new HashMap<>());
+
+    final Annotation noHashAnnotation = noHashAnnotator.execute(ctx, data);
+
+    assert AnnotationLayer.MOCK.equals(noHashAnnotation.getLayer());
   }
 }

--- a/src/test/java/com/alvarium/annotators/AnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/AnnotatorTest.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
-import com.alvarium.contracts.AnnotationLayer;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.serializers.AnnotatorConfigConverter;
@@ -75,7 +75,7 @@ public class AnnotatorTest {
     }
     
     final AnnotatorConfig[] annotators = {satisfiedAnnotatorInfo, unsatisfiedAnnotatorInfo};
-    final SdkInfo config = new SdkInfo(annotators, hash, signature, null);
+    final SdkInfo config = new SdkInfo(annotators, hash, signature, null, LayerType.Application);
 
     final Logger logger = LogManager.getRootLogger();
     Configurator.setRootLevel(Level.DEBUG);
@@ -109,7 +109,7 @@ public class AnnotatorTest {
     final AnnotatorConfig annotatorInfo = gson.fromJson(mockConfig, AnnotatorConfig.class);
 
     final AnnotatorConfig[] annotators = {annotatorInfo};
-    final SdkInfo noHashConfig = new SdkInfo(annotators, noHash, signature, null);
+    final SdkInfo noHashConfig = new SdkInfo(annotators, noHash, signature, null, LayerType.Application);
 
     final Logger logger = LogManager.getRootLogger();
     Configurator.setRootLevel(Level.DEBUG);
@@ -140,7 +140,7 @@ public class AnnotatorTest {
     final AnnotatorConfig annotatorInfo = gson.fromJson(mockConfig, AnnotatorConfig.class);
 
     final AnnotatorConfig[] annotators = {annotatorInfo};
-    final SdkInfo noHashConfig = new SdkInfo(annotators, noHash, signature, null);
+    final SdkInfo noHashConfig = new SdkInfo(annotators, noHash, signature, null, LayerType.Application);
 
     final Logger logger = LogManager.getRootLogger();
     Configurator.setRootLevel(Level.DEBUG);
@@ -153,6 +153,6 @@ public class AnnotatorTest {
 
     final Annotation noHashAnnotation = noHashAnnotator.execute(ctx, data);
 
-    assert AnnotationLayer.MOCK.equals(noHashAnnotation.getLayer());
+    assert LayerType.Application.equals(noHashAnnotation.getLayer());
   }
 }

--- a/src/test/java/com/alvarium/annotators/ChecksumAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/ChecksumAnnotatorTest.java
@@ -29,6 +29,7 @@ import org.junit.rules.TemporaryFolder;
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashProvider;
 import com.alvarium.hash.HashProviderFactory;
@@ -69,7 +70,7 @@ public class ChecksumAnnotatorTest {
             );
 
             final AnnotatorConfig[] annotators = {checksumCfg};  
-            final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
+            final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null, LayerType.Application);
 
             // init logger
             final Logger logger = LogManager.getRootLogger();

--- a/src/test/java/com/alvarium/annotators/PkiAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/PkiAnnotatorTest.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.serializers.AnnotatorConfigConverter;
@@ -66,7 +67,7 @@ public class PkiAnnotatorTest {
 
     final AnnotatorConfig pkiCfg = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {pkiCfg};  
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null, LayerType.Application);
     final Annotator annotator = annotatorFactory.getAnnotator(pkiCfg, config, logger);
     final Annotation annotation = annotator.execute(ctx, data);
     assertTrue("isSatisfied should be true", annotation.getIsSatisfied());
@@ -95,7 +96,7 @@ public class PkiAnnotatorTest {
 
     final AnnotatorConfig pkiCfg = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {pkiCfg};   
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null, LayerType.Application);
     final Annotator annotator = annotatorFactory.getAnnotator(pkiCfg, config, logger);
 
     final Annotation annotation = annotator.execute(ctx, data);

--- a/src/test/java/com/alvarium/annotators/PkiHttpAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/PkiHttpAnnotatorTest.java
@@ -26,6 +26,7 @@ import com.alvarium.annotators.http.RequestHandlerException;
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
 import com.alvarium.contracts.DerivedComponent;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.serializers.AnnotatorConfigConverter;
@@ -96,7 +97,7 @@ public class PkiHttpAnnotatorTest {
 
     final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {annotatorInfo};  
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null, LayerType.Application);
     final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     final Annotation annotation = annotator.execute(ctx, data);
     assertTrue("isSatisfied should be true", annotation.getIsSatisfied());
@@ -128,7 +129,7 @@ public class PkiHttpAnnotatorTest {
 
     final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {annotatorInfo};  
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null, LayerType.Application);
     final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     annotator.execute(ctx, data);
   }
@@ -157,7 +158,7 @@ public class PkiHttpAnnotatorTest {
 
     final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {annotatorInfo};  
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null, LayerType.Application);
     final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     Annotation annotation = annotator.execute(ctx, data);
     assertFalse("isSatisfied should be false", annotation.getIsSatisfied());
@@ -185,7 +186,7 @@ public class PkiHttpAnnotatorTest {
     
     final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {annotatorInfo};  
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null, LayerType.Application);
     final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     final Annotation annotation = annotator.execute(ctx, data);
     assertFalse("isSatisfied should be false", annotation.getIsSatisfied());
@@ -213,7 +214,7 @@ public class PkiHttpAnnotatorTest {
 
     final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {annotatorInfo};  
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null, LayerType.Application);
     final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     final Annotation annotation = annotator.execute(ctx, data);
     assertFalse("isSatisfied should be false", annotation.getIsSatisfied());

--- a/src/test/java/com/alvarium/annotators/SbomAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/SbomAnnotatorTest.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.serializers.AnnotatorConfigConverter;
@@ -89,7 +90,7 @@ public class SbomAnnotatorTest {
     ); 
 
     final AnnotatorConfig[] annotators = {annotatorInfo};  
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null, LayerType.Application);
 
     // init logger
     final Logger logger = LogManager.getRootLogger();

--- a/src/test/java/com/alvarium/annotators/SourceAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/SourceAnnotatorTest.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.serializers.AnnotatorConfigConverter;
@@ -57,7 +58,7 @@ public class SourceAnnotatorTest {
     ); 
     System.out.println("hello " + annotatorInfo.getKind());
     final AnnotatorConfig[] annotators = {annotatorInfo};  
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null, LayerType.Application);
 
             // init logger
     final Logger logger = LogManager.getRootLogger();

--- a/src/test/java/com/alvarium/annotators/SourceCodeAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/SourceCodeAnnotatorTest.java
@@ -32,6 +32,7 @@ import org.junit.rules.TemporaryFolder;
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashProvider;
 import com.alvarium.hash.HashProviderFactory;
@@ -72,7 +73,7 @@ public class SourceCodeAnnotatorTest {
                             AnnotatorConfig.class
                 );                 
                 final AnnotatorConfig[] annotators = {annotatorInfo};  
-                final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
+                final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null, LayerType.Application);
                         // init logger
                 final Logger logger = LogManager.getRootLogger();
                 Configurator.setRootLevel(Level.DEBUG);

--- a/src/test/java/com/alvarium/annotators/TlsAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/TlsAnnotatorTest.java
@@ -24,6 +24,7 @@ import javax.net.ssl.SSLSocketFactory;
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.serializers.AnnotatorConfigConverter;
@@ -65,7 +66,7 @@ public class TlsAnnotatorTest {
                 AnnotatorConfig.class
     );      
     final AnnotatorConfig[] annotators = {annotatorInfo};  
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null, LayerType.Application);
     final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger); 
     
     // dummy data

--- a/src/test/java/com/alvarium/annotators/TpmAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/TpmAnnotatorTest.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.serializers.AnnotatorConfigConverter;
@@ -61,7 +62,7 @@ public class TpmAnnotatorTest {
                 AnnotatorConfig.class
     );       
     final AnnotatorConfig[] annotators = {annotatorInfo};  
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.MD5Hash), sign, null, LayerType.Application);
     Annotator tpm = factory.getAnnotator(annotatorInfo, config, logger);
     
     PropertyBag ctx = new ImmutablePropertyBag(new HashMap<String, Object>());

--- a/src/test/java/com/alvarium/annotators/VulnerabilityAnnotatorTest.java
+++ b/src/test/java/com/alvarium/annotators/VulnerabilityAnnotatorTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import com.alvarium.SdkInfo;
 import com.alvarium.contracts.Annotation;
 import com.alvarium.contracts.AnnotationType;
+import com.alvarium.contracts.LayerType;
 import com.alvarium.hash.HashInfo;
 import com.alvarium.hash.HashType;
 import com.alvarium.serializers.AnnotatorConfigConverter;
@@ -58,7 +59,7 @@ public class VulnerabilityAnnotatorTest {
 
     final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {annotatorInfo};
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null, LayerType.Application);
 
     final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     
@@ -107,7 +108,7 @@ public class VulnerabilityAnnotatorTest {
     final SignatureInfo sigInfo = new SignatureInfo(pubKey, privKey);
     final AnnotatorConfig annotatorInfo = this.getAnnotatorCfg();
     final AnnotatorConfig[] annotators = {annotatorInfo};
-    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null);
+    final SdkInfo config = new SdkInfo(annotators, new HashInfo(HashType.SHA256Hash), sigInfo, null, LayerType.Application);
 
     final Annotator annotator = annotatorFactory.getAnnotator(annotatorInfo, config, logger);
     

--- a/src/test/java/com/alvarium/contracts/AnnotationListTest.java
+++ b/src/test/java/com/alvarium/contracts/AnnotationListTest.java
@@ -33,6 +33,7 @@ public class AnnotationListTest {
       "key", 
       HashType.NoHash,
       "host", 
+      "tag",
       AnnotationType.MOCK, 
       "signature", 
       true, 

--- a/src/test/java/com/alvarium/contracts/AnnotationListTest.java
+++ b/src/test/java/com/alvarium/contracts/AnnotationListTest.java
@@ -34,6 +34,7 @@ public class AnnotationListTest {
       HashType.NoHash,
       "host", 
       "tag",
+      AnnotationLayer.MOCK,
       AnnotationType.MOCK, 
       "signature", 
       true, 

--- a/src/test/java/com/alvarium/contracts/AnnotationListTest.java
+++ b/src/test/java/com/alvarium/contracts/AnnotationListTest.java
@@ -34,7 +34,7 @@ public class AnnotationListTest {
       HashType.NoHash,
       "host", 
       "tag",
-      AnnotationLayer.MOCK,
+      LayerType.Application,
       AnnotationType.MOCK, 
       "signature", 
       true, 
@@ -52,6 +52,7 @@ public class AnnotationListTest {
     "\"hash\":\"md5\"," +
     "\"host\":\"host\"," + 
     "\"kind\":\"tpm\"," + 
+    "\"layer\":\"app\"," + 
     "\"signature\":\"signature\"," +
     "\"isSatisfied\":true," +
     "\"timestamp\":\"2021-10-13T07:55:33.585017-07:00\"}";

--- a/src/test/java/com/alvarium/contracts/AnnotationListTest.java
+++ b/src/test/java/com/alvarium/contracts/AnnotationListTest.java
@@ -51,6 +51,7 @@ public class AnnotationListTest {
     "\"hash\":\"md5\"," +
     "\"host\":\"host\"," + 
     "\"kind\":\"tpm\"," + 
+    "\"tag\":\"9c0f17daa5cfefb0302d6f8650899b0863120e4c\"," + 
     "\"layer\":\"app\"," + 
     "\"signature\":\"signature\"," +
     "\"isSatisfied\":true," +

--- a/src/test/java/com/alvarium/contracts/AnnotationListTest.java
+++ b/src/test/java/com/alvarium/contracts/AnnotationListTest.java
@@ -33,7 +33,6 @@ public class AnnotationListTest {
       "key", 
       HashType.NoHash,
       "host", 
-      "tag",
       LayerType.Application,
       AnnotationType.MOCK, 
       "signature", 

--- a/src/test/java/com/alvarium/contracts/AnnotationTest.java
+++ b/src/test/java/com/alvarium/contracts/AnnotationTest.java
@@ -43,7 +43,7 @@ public class AnnotationTest {
 
   @Test
   public void toJsonShouldReturnTheRightRepresentation() {
-    Annotation annotation = new Annotation("key", HashType.MD5Hash, "host", "tag", AnnotationType.TPM,
+    Annotation annotation = new Annotation("key", HashType.MD5Hash, "host", "tag", AnnotationLayer.TPM, AnnotationType.TPM,
         "signature", true, testTimestamp);
     String result = annotation.toJson();
     System.out.println(result);

--- a/src/test/java/com/alvarium/contracts/AnnotationTest.java
+++ b/src/test/java/com/alvarium/contracts/AnnotationTest.java
@@ -43,7 +43,7 @@ public class AnnotationTest {
 
   @Test
   public void toJsonShouldReturnTheRightRepresentation() {
-    Annotation annotation = new Annotation("key", HashType.MD5Hash, "host", "tag", LayerType.Application, AnnotationType.TPM,
+    Annotation annotation = new Annotation("key", HashType.MD5Hash, "host", LayerType.Application, AnnotationType.TPM,
         "signature", true, testTimestamp);
     String result = annotation.toJson();
     System.out.println(result);

--- a/src/test/java/com/alvarium/contracts/AnnotationTest.java
+++ b/src/test/java/com/alvarium/contracts/AnnotationTest.java
@@ -43,7 +43,7 @@ public class AnnotationTest {
 
   @Test
   public void toJsonShouldReturnTheRightRepresentation() {
-    Annotation annotation = new Annotation("key", HashType.MD5Hash, "host", AnnotationType.TPM,
+    Annotation annotation = new Annotation("key", HashType.MD5Hash, "host", "tag", AnnotationType.TPM,
         "signature", true, testTimestamp);
     String result = annotation.toJson();
     System.out.println(result);

--- a/src/test/java/com/alvarium/contracts/AnnotationTest.java
+++ b/src/test/java/com/alvarium/contracts/AnnotationTest.java
@@ -43,7 +43,7 @@ public class AnnotationTest {
 
   @Test
   public void toJsonShouldReturnTheRightRepresentation() {
-    Annotation annotation = new Annotation("key", HashType.MD5Hash, "host", "tag", AnnotationLayer.TPM, AnnotationType.TPM,
+    Annotation annotation = new Annotation("key", HashType.MD5Hash, "host", "tag", LayerType.Application, AnnotationType.TPM,
         "signature", true, testTimestamp);
     String result = annotation.toJson();
     System.out.println(result);

--- a/src/test/java/com/alvarium/mock-info.json
+++ b/src/test/java/com/alvarium/mock-info.json
@@ -1,5 +1,6 @@
 
 {
+  "layer": "app",
   "annotators": [
     {
       "kind": "tpm"

--- a/src/test/java/com/alvarium/sdk-info.json
+++ b/src/test/java/com/alvarium/sdk-info.json
@@ -1,4 +1,5 @@
 {
+  "layer": "app",
   "annotators": [
     {
       "kind": "tpm"


### PR DESCRIPTION
Fix #130 
- Add Tag field in Annotation
- Add Layer field in Annotation
- Fetch Layer value from Sdk config
- Update existing tests and Add `mockAnnotatorShouldReturnTag` and `mockAnnotatorShouldReturnLayer` tests